### PR TITLE
infra: Adding autolabeler configuration.

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,66 @@
+documentation:                  ["*.rst", "docs"]
+
+files-definition:               ["definition.json"]
+
+files-layout-gds:               ["*.gds"]
+files-layout-lef-magic:         ["*.magic.lef"]
+files-layout-lef:               ["*.lef"]
+
+files-model-behavioral-verilog: ["*.behavioral.v"]
+files-model-functional-verilog: ["*.functional.v"]
+files-model-spice:              ["*.spice"]
+# files-model-verilog
+
+files-netlist-cdl:              ["*.cdl"]
+files-netlist-tsv:              ["*.netlist.tsv"]
+
+files-powerpins:                ["*.pp.*"]
+
+files-schematic-svg:            ["*.schematic.svg"]
+
+files-symbol-svg:               ["*.symbol.svg"]
+files-symbol-verilog:           ["*.symbol.v"]
+
+files-timing-json:              ["*.lib.json"]
+# files-timing-liberty:         ["*.lib"]
+
+files-testbench-verilog:        ["*.tb.v"]
+
+infrastructure:                 [".github", "travis", "kokoro"]
+
+lib-sky130_ef_io:               ["sky130_fd_ef_io"]
+
+lib-sky130_fd_pr_base:          ["sky130_fd_pr_base"]
+lib-sky130_fd_pr_rf:            ["sky130_fd_pr_rf"]
+lib-sky130_fd_pr_rf2:           ["sky130_fd_pr_rf2"]
+
+lib-sky130_fd_sc_hd:            ["sky130_fd_sc_hd"]
+lib-sky130_fd_sc_hdll:          ["sky130_fd_sc_hdll"]
+lib-sky130_fd_sc_hs:            ["sky130_fd_sc_hs"]
+lib-sky130_fd_sc_hvl:           ["sky130_fd_sc_hvl"]
+lib-sky130_fd_sc_lp:            ["sky130_fd_sc_lp"]
+lib-sky130_fd_sc_ls:            ["sky130_fd_sc_ls"]
+lib-sky130_fd_sc_ms:            ["sky130_fd_sc_ms"]
+
+lib-sky130_fd_sp_flash:         ["sky130_fd_sp_flash"]
+lib-sky130_fd_sp_sram:          ["sky130_fd_sp_sram"]
+
+lib-sky130_osu_sc:              ["sky130_osu_sc"]
+
+# scripts-documentation
+scripts-python:                 ["*.py"]
+
+# tools-BAG
+# tools-Cadence-Innovus
+# tools-Cadence-Virtuoso
+# tools-FASoC
+# tools-Magic
+# tools-Mentor-Calibre
+# tools-OpenRAM
+# tools-OpenROAD
+
+# type-bug
+# type-duplicate
+# type-enhancement
+# type-question
+# type-todo


### PR DESCRIPTION
See https://github.com/google/skywater-pdk/issues/36.

Currently uses the [Probot Autolabeler](https://github.com/apps/probot-autolabeler) as I have used that before. It should probably be converted to use one of the GitHub actions in the future.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>