### PR TITLE
Makefile: Add a make lint-python command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ git:
 install:
  - git describe
  - make env
+ - python3 -m pip install flake8
 
 script:
+ - make lint-python
  - source .github/travis/common.sh
  - rm -f README.rst && make README.rst
  - .github/travis/git-check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,23 +14,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-os: linux
-dist: focal
-language: shell
+language: minimal
 
 git:
   submodules: false
   depth: false
 
 install:
-  - git describe
-  - python3 -m pip install flake8
-
-before_script:
-  - make lint-python
-  - make env
+ - git describe
+ - make env
 
 script:
-  - source .github/travis/common.sh
-  - rm -f README.rst && make README.rst
-  - .github/travis/git-check.sh
+ - source .github/travis/common.sh
+ - rm -f README.rst && make README.rst
+ - .github/travis/git-check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-os linux
+os: linux
 dist: focal
 language: shell
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,14 @@ git:
   depth: false
 
 install:
- - git describe
- - make env
- - python3 -m pip install flake8
+  - git describe
+  - python3 -m pip install flake8
+
+before_script:
+  - make lint-python
+  - make env
 
 script:
- - make lint-python
- - source .github/travis/common.sh
- - rm -f README.rst && make README.rst
- - .github/travis/git-check.sh
+  - source .github/travis/common.sh
+  - rm -f README.rst && make README.rst
+  - .github/travis/git-check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-language: minimal
+os linux
+dist: focal
+language: shell
 
 git:
   submodules: false

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ lint-python:
 .PHONY: lint-python
 
 
-check: check-licenses
-	lint-python
+check: check-licenses lint-python
 	@true
 
 all: README.rst

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ check-licenses:
 
 .PHONY: check-licenses
 
+lint-python:
+	@python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+.PHONY: lint-python
+
 
 check: check-licenses
 	@true

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ check-licenses:
 .PHONY: check-licenses
 
 lint-python:
-	@python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 .PHONY: lint-python
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ lint-python:
 
 
 check: check-licenses
+	lint-python
 	@true
 
 all: README.rst

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ check-licenses:
 .PHONY: check-licenses
 
 lint-python:
-	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	$(IN_CONDA_ENV) flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 .PHONY: lint-python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+flake8
+
 # rst_include tool as GitHub doesn't support `.. include::` when rendering
 # previews.
 rst_include


### PR DESCRIPTION
Fixes #45

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR

If `make lint-python` is not run before `make env` then it fails to complete in 10 minutes which times out Travis CI.