### PR TITLE
docs: Fixing requirements.txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,10 +83,10 @@ master_doc = 'index'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:
     html_context = {
-        "display_github": True,  # Integrate GitHub
-        "github_user": "mithro",  # Username
-        "github_repo": "python-sphinx-verilog",  # Repo name
-        "github_version": "master",  # Version
+        "display_github": True,         # Integrate GitHub
+        "github_user": "google",        # Username
+        "github_repo": "skywater-pdk",  # Repo name
+        "github_version": "master",     # Version
         "conf_py_path": "/doc/",
     }
 else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinxcontrib_verilog_diagrams',
+    'sphinxcontrib_hdl_diagrams',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,11 +4,13 @@ docutils
 sphinx
 sphinx-autobuild
 
+# Verilog domain
+sphinx-verilog-domain
 # Verilog diagrams using Yosys + netlistsvg
-git+https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams.git#egg=sphinxcontrib-verilog-diagrams
+sphinxcontrib-hdl-diagrams
 
 # Module diagrams
-symbolator
+git+https://github.com/SymbiFlow/symbolator.git#egg=symbolator
 
 # pycairo
 # vext.gi


### PR DESCRIPTION
 * Install sphinx-verilog-domain.
 * Update for the sphinxcontrib-verilog-diagrams name change.
 * Use the SymbiFlow version of Symbolator.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>