### PR TITLE
env: Lock to Python 3.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python
+- python=3.8
 - pip
 - yosys
 - netlistsvg


### PR DESCRIPTION
Python 3.9 has been released but a lot of packages have not yet moved
forward.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>