### PR TITLE
Add repository links to the main page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,14 @@ Current Status - |current-status|
 .. include:: status.rst
     :start-after: current_status_text
 
+Resources
+=========
+
+The latest SkyWater SKY130 PDK design resources can be downloaded from the following repositories:
+
+* `github.com/google/skywater-pdk <https://github.com/google/skywater-pdk>`_
+* `cs.opensource.google/skywater-pdk <https://cs.opensource.google/skywater-pdk>`_
+* `foss-eda-tools.googlesource.com/skywater-pdk <https://foss-eda-tools.googlesource.com/skywater-pdk/>`_
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Resources
 The latest SkyWater SKY130 PDK design resources can be downloaded from the following repositories:
 
 * `On Github @ google/skywater-pdk <https://github.com/google/skywater-pdk>`_
-* `cs.opensource.google/skywater-pdk <https://cs.opensource.google/skywater-pdk>`_
+* `Google CodeSearch interface @ https://cs.opensource.google/skywater-pdk <https://cs.opensource.google/skywater-pdk>`_
 * `foss-eda-tools.googlesource.com/skywater-pdk <https://foss-eda-tools.googlesource.com/skywater-pdk/>`_
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Resources
 
 The latest SkyWater SKY130 PDK design resources can be downloaded from the following repositories:
 
-* `github.com/google/skywater-pdk <https://github.com/google/skywater-pdk>`_
+* `On Github @ google/skywater-pdk <https://github.com/google/skywater-pdk>`_
 * `cs.opensource.google/skywater-pdk <https://cs.opensource.google/skywater-pdk>`_
 * `foss-eda-tools.googlesource.com/skywater-pdk <https://foss-eda-tools.googlesource.com/skywater-pdk/>`_
 


### PR DESCRIPTION
Adds links to 3 repositories with PDK design resources to the main page of the RTD. 
The links include GitHub, foss-eda-tools and Google codesearch

Fixes #159
