### PR TITLE
Added script converting rst subscript and equations to math. 

### DIFF
--- a/docs/rules/device-details.rst
+++ b/docs/rules/device-details.rst
@@ -12,7 +12,7 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  \|V\ :sub:`c0` – V\ :sub:`c1`\ \| = 0 to 5.0V
+-  :math:`|V_{c0} – V_{c1}| = 0` to 5.0V
 
 Details
 ~~~~~~~
@@ -61,7 +61,7 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  \|V\ :sub:`0` – V\ :sub:`1`\ \| = 0 to 2.0V
+-  :math:`|V_0 – V_1| = 0` to 2.0V
 
 Details
 ~~~~~~~
@@ -110,7 +110,7 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  \|V\ :sub:`c0` – V\ :sub:`c1`\ \| = 0 to 5.5V
+-  :math:`|V_{c0} – V_{c1}| = 0` to 5.5V
 
 Details
 ~~~~~~~
@@ -200,7 +200,7 @@ Spice Model Information
 
 Operating regime where SPICE models are valid
 
--  \|V\ :sub:`d0` – V\ :sub:`d1`\ \| = 0 to 5.0V
+-  :math:`|V_{d0} – V_{d1}| = 0` to 5.0V
 
 Details
 ~~~~~~~
@@ -260,9 +260,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 11.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
--  V\ :sub:`GS` = 0 to 5.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
--  V\ :sub:`BS` = 0 to -5.5V, (:model:`sky130_fd_pr__nfet_g5v0d10v5`), +0.3 to -5.5V (:model:`sky130_fd_pr__nfet_05v0_nvt`), 0 to -1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{DS} = 0` to 11.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{GS} = 0` to 5.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{BS} = 0` to -5.5V, (:model:`sky130_fd_pr__nfet_g5v0d10v5`), +0.3 to -5.5V (:model:`sky130_fd_pr__nfet_05v0_nvt`), 0 to -1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
 
 Details
 ~~~~~~~
@@ -304,9 +304,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 11.0V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -5.5V
+-  :math:`V_{DS} = 0` to 11.0V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -5.5V
 
 Details
 ~~~~~~~
@@ -341,10 +341,10 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +16V (V:sub:`GS` = 0)
--  V\ :sub:`DS` = 0 to +11V (V:sub:`GS` > 0)
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +16V (\ :math:`V_{GS} = 0`\ )
+-  :math:`V_{DS} = 0` to +11V (\ :math:`V_{GS} > 0`\ )
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~
@@ -379,9 +379,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 1.95V
--  V\ :sub:`GS` = 0 to 1.95V
--  V\ :sub:`BS` = +0.3 to -1.95V
+-  :math:`V_{DS} = 0` to 1.95V
+-  :math:`V_{GS} = 0` to 1.95V
+-  :math:`V_{BS} = +0.3` to -1.95V
 
 Details
 ~~~~~~~
@@ -404,7 +404,7 @@ The symbol of the :model:`sky130_fd_pr__nfet_01v8_lvt` (1.8V low-VT NMOS FET) is
 
 |symbol-nfet_01v8_lvt|
 
-The cross-section of the low-VT NMOS FET is shown below. The cross-section is identical to the std NMOS FET except for the V\ :sub:`T` adjust implants (to achieve the lower V\ :sub:`T`)
+The cross-section of the low-VT NMOS FET is shown below. The cross-section is identical to the std NMOS FET except for the :math:`V_T` adjust implants (to achieve the lower :math:`V_T`)
 
 |cross-section-nfet_01v8_lvt|
 
@@ -423,9 +423,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 1.95V
--  V\ :sub:`GS` = 0 to 1.95V
--  V\ :sub:`BS` = +0.3 to -1.95V
+-  :math:`V_{DS} = 0` to 1.95V
+-  :math:`V_{GS} = 0` to 1.95V
+-  :math:`V_{BS} = +0.3` to -1.95V
 
 Details
 ~~~~~~~
@@ -462,9 +462,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid for :model:`sky130_fd_pr__nfet_03v3_nvt`
 
--  V\ :sub:`DS` = 0 to 3.3V
--  V\ :sub:`GS` = 0 to 3.3V
--  V\ :sub:`BS` = 0 to -3.3V
+-  :math:`V_{DS} = 0` to 3.3V
+-  :math:`V_{GS} = 0` to 3.3V
+-  :math:`V_{BS} = 0` to -3.3V
 
 Details
 ~~~~~~~
@@ -503,9 +503,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid for :model:`sky130_fd_pr__nfet_05v0_nvt`
 
--  V\ :sub:`DS` = 0 to 5.5V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = +0.3 to -5.5V
+-  :math:`V_{DS} = 0` to 5.5V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = +0.3` to -5.5V
 
 Details
 ~~~~~~~
@@ -545,9 +545,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~
@@ -589,9 +589,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~
@@ -628,9 +628,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~
@@ -667,9 +667,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~
@@ -703,9 +703,9 @@ Spice Model Information
 
 Operating regime where SPICE models are valid
 
--  \|V\ :sub:`CE`\ \| = 0 to 5.0V
--  \|V\ :sub:`BE`\ \| = 0 to 5.0V
--  I\ :sub:`CE` = 0.01 to 10 µA/µm\ :sup:`2`
+-  :math:`|V_{CE}| = 0` to 5.0V
+-  :math:`|V_{BE}| = 0` to 5.0V
+-  :math:`I_{CE} = 0.01` to 10 µA/µm\ :sup:`2`
 
 Details
 ~~~~~~~
@@ -755,9 +755,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -11.0V
--  V\ :sub:`GS` = 0 to -5.5V
--  V\ :sub:`BS` = 0 to +5.5V
+-  :math:`V_{DS} = 0` to -11.0V
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +5.5V
 
 Details
 ~~~~~~~
@@ -800,10 +800,10 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to -16V (V:sub:`GS` = 0)
--  V\ :sub:`DS` = 0 to -10V (V:sub:`GS` < 0)
--  V\ :sub:`GS` = 0 to -5.5V
--  V\ :sub:`BS` = 0 to +2.0V
+-  :math:`V_{DS} = 0` to -16V (\ :math:`V_{GS} = 0`\ )
+-  :math:`V_{DS} = 0` to -10V (\ :math:`V_{GS} < 0`\ )
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +2.0V
 
 Details
 ~~~~~~~
@@ -838,9 +838,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -1.95V
--  V\ :sub:`GS` = 0 to -1.95V
--  V\ :sub:`BS` = -0.1 to +1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~
@@ -863,7 +863,7 @@ The symbol of the :model:`sky130_fd_pr__pfet_01v8_hvt` (1.8V high-VT PMOS FET) i
 
 |symbol-pfet_01v8_hvt|
 
-The cross-section of the high-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the V\ :sub:`T` adjust implants (to achieve the higher V\ :sub:`T`)
+The cross-section of the high-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the higher :math:`V_T`)
 
 |cross-section-pfet_01v8_hvt|
 
@@ -882,9 +882,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -1.95V
--  V\ :sub:`GS` = 0 to -1.95V
--  V\ :sub:`BS` = -0.1 to +1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~
@@ -907,7 +907,7 @@ The symbol of the :model:`sky130_fd_pr__pfet_01v8_lvt` (1.8V low-VT PMOS FET) is
 
 |symbol-pfet_01v8_lvt|
 
-The cross-section of the low-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the V\ :sub:`T` adjust implants (to achieve the lower V\ :sub:`T`)
+The cross-section of the low-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the lower :math:`V_T`)
 
 |cross-section-pfet_01v8_lvt|
 
@@ -926,9 +926,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -1.95V
--  V\ :sub:`GS` = 0 to -1.95V
--  V\ :sub:`BS` = -0.1 to +1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~
@@ -970,9 +970,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to -22V
--  V\ :sub:`GS` = 0 to -5.5V
--  V\ :sub:`BS` = 0 to +2.0V
+-  :math:`V_{DS} = 0` to -22V
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +2.0V
 
 Details
 ~~~~~~~
@@ -1014,9 +1014,9 @@ Spice Model Information
 
 Operating regime where SPICE models are valid
 
--  \|V\ :sub:`CE`\ \| = 0 to 5.0V
--  \|V\ :sub:`BE`\ \| = 0 to 5.0V
--  I\ :sub:`CE` = 0.01 to 10 µA/µm\ :sup:`2`
+-  :math:`|V_{CE}| = 0` to 5.0V
+-  :math:`|V_{BE}| = 0` to 5.0V
+-  :math:`I_{CE} = 0.01` to 10 µA/µm\ :sup:`2`
 
 Details
 ~~~~~~~
@@ -1123,7 +1123,7 @@ Spice Model Information
 
 Operating ranges where SPICE models are valid
 
--  \|V\ :sub:`r0` – V\ :sub:`r1`\ \| = 0 to 5.0V
+-  :math:`|V_{r0} – V_{r1}| = 0` to 5.0V
 -  Currents up to 500 µA/µm of width (preferred use ≤ 100 µA/µm)
 
 Details
@@ -1141,15 +1141,15 @@ They are modeled as subcircuits, using a conventional resistor model combined wi
 
 The fixed-width resistors are modeled using the equation
 
-*R\ :sub:`0`* = head/tail resistance [Ω] (dominated by the slot licons)
+*\ :math:`R_0`\ * = head/tail resistance [Ω] (dominated by the slot licons)
 
-*R\ :sub:`1`* = body resistance [Ω/µm] = R\ :sub:`SH`/W
+*\ :math:`R_1`\ * = body resistance [Ω/µm] = :math:`R_{SH}`/W
 
 A top-down schematic drawing of the precision resistor is shown below.
 
 |res_high_po|
 
-In addition to the R\ :sub:`0` and R\ :sub:`1` values, several fixed-value resistors are measured at e-test, as shown in the table below:
+In addition to the :math:`R_0` and :math:`R_1` values, several fixed-value resistors are measured at e-test, as shown in the table below:
 
 
 .. include:: device-details/res_high/res_high-table0.rst
@@ -1196,7 +1196,7 @@ Spice Model Information
 
 Operating ranges where SPICE models are valid
 
--  \|V\ :sub:`r0` – V\ :sub:`r1`\ \| = 0 to 5.0V
+-  :math:`|V_{r0} – V_{r1}| = 0` to 5.0V
 -  Currents up to 500 µA/µm of width (preferred use ≤ 100 µA/µm)
 
 Details
@@ -1304,9 +1304,9 @@ A Dual-Port SRAM is currently being designed using a similar approach. Compilers
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 1.8V
--  V\ :sub:`GS` = 0 to 1.8V
--  V\ :sub:`BS` = 0 to -1.8V
+-  :math:`V_{DS} = 0` to 1.8V
+-  :math:`V_{GS} = 0` to 1.8V
+-  :math:`V_{BS} = 0` to -1.8V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/cap_mim/index.rst
+++ b/docs/rules/device-details/cap_mim/index.rst
@@ -9,7 +9,7 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  \|V\ :sub:`c0` – V\ :sub:`c1`\ \| = 0 to 5.0V
+-  :math:`|V_{c0} – V_{c1}| = 0` to 5.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/cap_var/index.rst
+++ b/docs/rules/device-details/cap_var/index.rst
@@ -10,7 +10,7 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  \|V\ :sub:`0` – V\ :sub:`1`\ \| = 0 to 2.0V
+-  :math:`|V_0 – V_1| = 0` to 2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/cap_vpp/index.rst
+++ b/docs/rules/device-details/cap_vpp/index.rst
@@ -15,7 +15,7 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  \|V\ :sub:`c0` – V\ :sub:`c1`\ \| = 0 to 5.5V
+-  :math:`|V_{c0} – V_{c1}| = 0` to 5.5V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/diodes/index.rst
+++ b/docs/rules/device-details/diodes/index.rst
@@ -11,7 +11,7 @@ Spice Model Information
 
 Operating regime where SPICE models are valid
 
--  \|V\ :sub:`d0` – V\ :sub:`d1`\ \| = 0 to 5.0V
+-  :math:`|V_{d0} – V_{d1}| = 0` to 5.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/esd_nfet/index.rst
+++ b/docs/rules/device-details/esd_nfet/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 11.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
--  V\ :sub:`GS` = 0 to 5.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
--  V\ :sub:`BS` = 0 to -5.5V, (:model:`sky130_fd_pr__nfet_g5v0d10v5`), +0.3 to -5.5V (:model:`sky130_fd_pr__nfet_05v0_nvt`), 0 to -1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{DS} = 0` to 11.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{GS} = 0` to 5.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{BS} = 0` to -5.5V, (:model:`sky130_fd_pr__nfet_g5v0d10v5`), +0.3 to -5.5V (:model:`sky130_fd_pr__nfet_05v0_nvt`), 0 to -1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_01v8/index.rst
+++ b/docs/rules/device-details/nfet_01v8/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 1.95V
--  V\ :sub:`GS` = 0 to 1.95V
--  V\ :sub:`BS` = +0.3 to -1.95V
+-  :math:`V_{DS} = 0` to 1.95V
+-  :math:`V_{GS} = 0` to 1.95V
+-  :math:`V_{BS} = +0.3` to -1.95V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_01v8_lvt/index.rst
+++ b/docs/rules/device-details/nfet_01v8_lvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 1.95V
--  V\ :sub:`GS` = 0 to 1.95V
--  V\ :sub:`BS` = +0.3 to -1.95V
+-  :math:`V_{DS} = 0` to 1.95V
+-  :math:`V_{GS} = 0` to 1.95V
+-  :math:`V_{BS} = +0.3` to -1.95V
 
 Details
 ~~~~~~~
@@ -34,7 +34,7 @@ The symbol of the :model:`sky130_fd_pr__nfet_01v8_lvt` (1.8V low-VT NMOS FET) is
 
 |symbol-nfet_01v8_lvt|
 
-The cross-section of the low-VT NMOS FET is shown below. The cross-section is identical to the std NMOS FET except for the V\ :sub:`T` adjust implants (to achieve the lower V\ :sub:`T`)
+The cross-section of the low-VT NMOS FET is shown below. The cross-section is identical to the std NMOS FET except for the :math:`V_T` adjust implants (to achieve the lower :math:`V_T`)
 
 |cross-section-nfet_01v8_lvt|
 

--- a/docs/rules/device-details/nfet_03v3_nvt/index.rst
+++ b/docs/rules/device-details/nfet_03v3_nvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid for :model:`sky130_fd_pr__nfet_03v3_nvt`
 
--  V\ :sub:`DS` = 0 to 3.3V
--  V\ :sub:`GS` = 0 to 3.3V
--  V\ :sub:`BS` = 0 to -3.3V
+-  :math:`V_{DS} = 0` to 3.3V
+-  :math:`V_{GS} = 0` to 3.3V
+-  :math:`V_{BS} = 0` to -3.3V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_05v0_nvt/index.rst
+++ b/docs/rules/device-details/nfet_05v0_nvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid for :model:`sky130_fd_pr__nfet_05v0_nvt`
 
--  V\ :sub:`DS` = 0 to 5.5V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = +0.3 to -5.5V
+-  :math:`V_{DS} = 0` to 5.5V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = +0.3` to -5.5V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_20v0/index.rst
+++ b/docs/rules/device-details/nfet_20v0/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_20v0_iso/index.rst
+++ b/docs/rules/device-details/nfet_20v0_iso/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_20v0_nvt/index.rst
+++ b/docs/rules/device-details/nfet_20v0_nvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_20v0_zvt/index.rst
+++ b/docs/rules/device-details/nfet_20v0_zvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +22V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_g11v0d16v0/index.rst
+++ b/docs/rules/device-details/nfet_g11v0d16v0/index.rst
@@ -9,10 +9,10 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to +16V (V:sub:`GS` = 0)
--  V\ :sub:`DS` = 0 to +11V (V:sub:`GS` > 0)
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -2.0V
+-  :math:`V_{DS} = 0` to +16V (\ :math:`V_{GS} = 0`\ )
+-  :math:`V_{DS} = 0` to +11V (\ :math:`V_{GS} > 0`\ )
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/nfet_g5v0d10v5/index.rst
+++ b/docs/rules/device-details/nfet_g5v0d10v5/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 11.0V
--  V\ :sub:`GS` = 0 to 5.5V
--  V\ :sub:`BS` = 0 to -5.5V
+-  :math:`V_{DS} = 0` to 11.0V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -5.5V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/npn_05v0/index.rst
+++ b/docs/rules/device-details/npn_05v0/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating regime where SPICE models are valid
 
--  \|V\ :sub:`CE`\ \| = 0 to 5.0V
--  \|V\ :sub:`BE`\ \| = 0 to 5.0V
--  I\ :sub:`CE` = 0.01 to 10 µA/µm\ :sup:`2`
+-  :math:`|V_{CE}| = 0` to 5.0V
+-  :math:`|V_{BE}| = 0` to 5.0V
+-  :math:`I_{CE} = 0.01` to 10 µA/µm\ :sup:`2`
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/npn_05v0/npn_05v0-table0.rst
+++ b/docs/rules/device-details/npn_05v0/npn_05v0-table0.rst
@@ -15,82 +15,82 @@
      - 18.14
      - 56.93
      - 
-     - NPN forward Current Gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =10 µA
+     - NPN forward Current Gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=10 µA`
 
    * - BFNPN1X1\_1P0
      - 36.72
      - 17.97
      - 55.38
      - 
-     - NPN forward Current Gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =1.0 µA
+     - NPN forward Current Gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=1.0 µA`
 
    * - BFNPN1X2\_17P5
      - 35.14
      - 16.98
      - 53.37
      - 
-     - NPN forward Current Gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =17.5 µA
+     - NPN forward Current Gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=17.5 µA`
 
    * - BFNPN1X2\_1P75
      - 34.57
      - 16.89
      - 52.2
      - 
-     - NPN forward Current Gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =1.75 µA
+     - NPN forward Current Gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=1.75 µA`
 
    * - BFNPNPOLY\_3P16
      - 125.28
      - 62.37
      - 500
      - 
-     - NPN forward Current Gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =3.16 µA
+     - NPN forward Current Gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=3.16 µA`
 
    * - BFNPNPOLY\_P316
      - 106.98
      - 55.94
      - 500
      - 
-     - NPN forward Current Gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =0.316 µA
+     - NPN forward Current Gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=0.316 µA`
 
    * - VBENPN1X1\_10P0
      - 0.7745
      - 0.7645
      - 0.7845
      - V
-     - NPN emitter-base voltage at I\ :sub:`E`\ =10 µA
+     - NPN emitter-base voltage at :math:`I_E=10 µA`
 
    * - VBENPN1X1\_1P0
      - 0.712
      - 0.702
      - 0.722
      - V
-     - NPN emitter-base voltage at I\ :sub:`E`\ =1.0 µA
+     - NPN emitter-base voltage at :math:`I_E=1.0 µA`
 
    * - VBENPN1X2\_17P5
      - 0.7745
      - 0.7645
      - 0.7845
      - V
-     - NPN emitter-base voltage at I\ :sub:`E`\ =17.5 µA
+     - NPN emitter-base voltage at :math:`I_E=17.5 µA`
 
    * - VBENPN1X2\_1P75
      - 0.712
      - 0.702
      - 0.722
      - V
-     - NPN emitter-base voltage at I\ :sub:`E`\ =1.75 µA
+     - NPN emitter-base voltage at :math:`I_E=1.75 µA`
 
    * - VBENPNPOLY\_3P16
      - 0.7073
      - 0.6933
      - 0.7213
      - V
-     - NPN emitter-base voltage at I\ :sub:`E`\ =3.16 µA
+     - NPN emitter-base voltage at :math:`I_E=3.16 µA`
 
    * - VBENPNPOLY\_P316
      - 0.6452
      - 0.6312
      - 0.6591
      - V
-     - NPN emitter-base voltage at I\ :sub:`E`\ =0.316 µA
+     - NPN emitter-base voltage at :math:`I_E=0.316 µA`
 

--- a/docs/rules/device-details/pfet_01v8/index.rst
+++ b/docs/rules/device-details/pfet_01v8/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -1.95V
--  V\ :sub:`GS` = 0 to -1.95V
--  V\ :sub:`BS` = -0.1 to +1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/pfet_01v8_hvt/index.rst
+++ b/docs/rules/device-details/pfet_01v8_hvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -1.95V
--  V\ :sub:`GS` = 0 to -1.95V
--  V\ :sub:`BS` = -0.1 to +1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~
@@ -34,7 +34,7 @@ The symbol of the :model:`sky130_fd_pr__pfet_01v8_hvt` (1.8V high-VT PMOS FET) i
 
 |symbol-pfet_01v8_hvt|
 
-The cross-section of the high-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the V\ :sub:`T` adjust implants (to achieve the higher V\ :sub:`T`)
+The cross-section of the high-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the higher :math:`V_T`)
 
 |cross-section-pfet_01v8_hvt|
 

--- a/docs/rules/device-details/pfet_01v8_lvt/index.rst
+++ b/docs/rules/device-details/pfet_01v8_lvt/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -1.95V
--  V\ :sub:`GS` = 0 to -1.95V
--  V\ :sub:`BS` = -0.1 to +1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~
@@ -34,7 +34,7 @@ The symbol of the :model:`sky130_fd_pr__pfet_01v8_lvt` (1.8V low-VT PMOS FET) is
 
 |symbol-pfet_01v8_lvt|
 
-The cross-section of the low-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the V\ :sub:`T` adjust implants (to achieve the lower V\ :sub:`T`)
+The cross-section of the low-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the lower :math:`V_T`)
 
 |cross-section-pfet_01v8_lvt|
 

--- a/docs/rules/device-details/pfet_20v0/index.rst
+++ b/docs/rules/device-details/pfet_20v0/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to -22V
--  V\ :sub:`GS` = 0 to -5.5V
--  V\ :sub:`BS` = 0 to +2.0V
+-  :math:`V_{DS} = 0` to -22V
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/pfet_g5v0d10v5/index.rst
+++ b/docs/rules/device-details/pfet_g5v0d10v5/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to -11.0V
--  V\ :sub:`GS` = 0 to -5.5V
--  V\ :sub:`BS` = 0 to +5.5V
+-  :math:`V_{DS} = 0` to -11.0V
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +5.5V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/pfet_g5v0d16v0/index.rst
+++ b/docs/rules/device-details/pfet_g5v0d16v0/index.rst
@@ -9,10 +9,10 @@ Spice Model Information
 
 Operating Voltages where SPICE models are valid, subject to SOA limitations:
 
--  V\ :sub:`DS` = 0 to -16V (V:sub:`GS` = 0)
--  V\ :sub:`DS` = 0 to -10V (V:sub:`GS` < 0)
--  V\ :sub:`GS` = 0 to -5.5V
--  V\ :sub:`BS` = 0 to +2.0V
+-  :math:`V_{DS} = 0` to -16V (\ :math:`V_{GS} = 0`\ )
+-  :math:`V_{DS} = 0` to -10V (\ :math:`V_{GS} < 0`\ )
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +2.0V
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/pnp_05v0/index.rst
+++ b/docs/rules/device-details/pnp_05v0/index.rst
@@ -9,9 +9,9 @@ Spice Model Information
 
 Operating regime where SPICE models are valid
 
--  \|V\ :sub:`CE`\ \| = 0 to 5.0V
--  \|V\ :sub:`BE`\ \| = 0 to 5.0V
--  I\ :sub:`CE` = 0.01 to 10 µA/µm\ :sup:`2`
+-  :math:`|V_{CE}| = 0` to 5.0V
+-  :math:`|V_{BE}| = 0` to 5.0V
+-  :math:`I_{CE} = 0.01` to 10 µA/µm\ :sup:`2`
 
 Details
 ~~~~~~~

--- a/docs/rules/device-details/pnp_05v0/pnp_05v0-table0.rst
+++ b/docs/rules/device-details/pnp_05v0/pnp_05v0-table0.rst
@@ -15,54 +15,54 @@
      - 7.51
      - 21.02
      - 
-     - PNP forward current gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =0.5 µA
+     - PNP forward current gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=0.5 µA`
 
    * - BF0P68\_5
      - 12.58
      - 6.59
      - 18.59
      - 
-     - PNP forward current gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =5.0 µA
+     - PNP forward current gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=5.0 µA`
 
    * - VBE0P68\_0P5
      - 0.7180
      - 0.7120
      - 0.7240
      - V
-     - PNP emitter-base voltage at I\ :sub:`E`\ =0.5 µA
+     - PNP emitter-base voltage at :math:`I_E=0.5 µA`
 
    * - VBE0P68\_5
      - 0.7847
      - 0.7790
      - 0.7904
      - V
-     - PNP emitter-base voltage at I\ :sub:`E`\ =5.0 µA
+     - PNP emitter-base voltage at :math:`I_E=5.0 µA`
 
    * - BF3P4\_0P1
      - 13.20
      - 5.93
      - 20.20
      - 
-     - PNP forward current gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =0.1 µA
+     - PNP forward current gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=0.1 µA`
 
    * - BF3P4\_10
      - 14.65
      - 6.10
      - 23.10
      - 
-     - PNP forward current gain (I\ :sub:`C`/I\ :sub:`B`) at I\ :sub:`E`\ =1.0 µA
+     - PNP forward current gain (\ :math:`\frac{I_C}{I_B})` at :math:`I_E=1.0 µA`
 
    * - VBE3P4\_0P1
      - 0.6129
      - 0.6087
      - 0.6172
      - V
-     - PNP emitter-base voltage at I\ :sub:`E`\ =0.1 µA
+     - PNP emitter-base voltage at :math:`I_E=0.1 µA`
 
    * - VBE3P4\_10
      - 0.7351
      - 0.7308
      - 0.7393
      - V
-     - PNP emitter-base voltage at I\ :sub:`E`\ =1.0 µA
+     - PNP emitter-base voltage at :math:`I_E=1.0 µA`
 

--- a/docs/rules/device-details/res_high/index.rst
+++ b/docs/rules/device-details/res_high/index.rst
@@ -9,7 +9,7 @@ Spice Model Information
 
 Operating ranges where SPICE models are valid
 
--  \|V\ :sub:`r0` – V\ :sub:`r1`\ \| = 0 to 5.0V
+-  :math:`|V_{r0} – V_{r1}| = 0` to 5.0V
 -  Currents up to 500 µA/µm of width (preferred use ≤ 100 µA/µm)
 
 Details
@@ -27,15 +27,15 @@ They are modeled as subcircuits, using a conventional resistor model combined wi
 
 The fixed-width resistors are modeled using the equation
 
-*R\ :sub:`0`* = head/tail resistance [Ω] (dominated by the slot licons)
+*\ :math:`R_0`\ * = head/tail resistance [Ω] (dominated by the slot licons)
 
-*R\ :sub:`1`* = body resistance [Ω/µm] = R\ :sub:`SH`/W
+*\ :math:`R_1`\ * = body resistance [Ω/µm] = :math:`R_{SH}`/W
 
 A top-down schematic drawing of the precision resistor is shown below.
 
 |res_high_po|
 
-In addition to the R\ :sub:`0` and R\ :sub:`1` values, several fixed-value resistors are measured at e-test, as shown in the table below:
+In addition to the :math:`R_0` and :math:`R_1` values, several fixed-value resistors are measured at e-test, as shown in the table below:
 
 
 .. include:: res_high-table0.rst

--- a/docs/rules/device-details/res_xhigh/index.rst
+++ b/docs/rules/device-details/res_xhigh/index.rst
@@ -9,7 +9,7 @@ Spice Model Information
 
 Operating ranges where SPICE models are valid
 
--  \|V\ :sub:`r0` – V\ :sub:`r1`\ \| = 0 to 5.0V
+-  :math:`|V_{r0} – V_{r1}| = 0` to 5.0V
 -  Currents up to 500 µA/µm of width (preferred use ≤ 100 µA/µm)
 
 Details

--- a/docs/rules/device-details/special_sonosfet/special_sonosfet-table1.rst
+++ b/docs/rules/device-details/special_sonosfet/special_sonosfet-table1.rst
@@ -4,11 +4,11 @@
 
 
    * - Condition
-     - V\ :sub:`G`
-     - V\ :sub:`D`
-     - V\ :sub:`B`
-     - V\ :sub:`S`
-     - V\ :sub:`WL`
+     - :math:`V_G`
+     - :math:`V_D`
+     - :math:`V_B`
+     - :math:`V_S`
+     - :math:`V_{WL}`
      - Pulse
 
    * - Read
@@ -36,7 +36,7 @@
      - 6 ms
 
    * - VT meas
-     - I\ :sub:`D` = 2.05µA
+     - :math:`I_D = 2.05`\ µA
      - +1.1
      - 0
      - 0

--- a/docs/rules/device-details/special_sram/index.rst
+++ b/docs/rules/device-details/special_sram/index.rst
@@ -11,9 +11,9 @@ A Dual-Port SRAM is currently being designed using a similar approach. Compilers
 
 Operating Voltages where SPICE models are valid
 
--  V\ :sub:`DS` = 0 to 1.8V
--  V\ :sub:`GS` = 0 to 1.8V
--  V\ :sub:`BS` = 0 to -1.8V
+-  :math:`V_{DS} = 0` to 1.8V
+-  :math:`V_{GS} = 0` to 1.8V
+-  :math:`V_{BS} = 0` to -1.8V
 
 Details
 ~~~~~~~


### PR DESCRIPTION
I've added a script which uses regular expressions to replace rst markup with :math: 
- subscripted variables converted from :sub: to :math:`x_y`
- equations (+ / - / * / = / |) with such variables clustered to single expression 
- fractions as :math:/frac{}{}
Updated rst files included in the commit.
Fixes #137 

Test:
https://antmicro-skywater-pdk-docs.readthedocs.io/en/137-improve-equations-and-fractions/rules/device-details.html