### PR TITLE
docs: Enable cloning the sky130_fd_io submodule.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,3 +27,8 @@ sphinx:
 
 conda:
   environment: environment.yml
+
+submodules:
+  include:
+   - libraries/sky130_fd_io/latest
+  recursive: false


### PR DESCRIPTION
Fixes #235 

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>