### PR TITLE
Fix footnote warnings - table footnotes included in parent documents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,6 +124,9 @@ exclude_patterns = [
     'code-of-conduct.rst',
     'rules/periphery-rules.rst',
     'rules/device-details/*/index.rst',
+    'rules/summary/*-key.rst',
+    'rules/layers/*-key.rst',
+    'rules/hv/*-key.rst',
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/docs/rules/layers/table-f2a-lvs-key.rst
+++ b/docs/rules/layers/table-f2a-lvs-key.rst
@@ -1,4 +1,5 @@
 Explanation of symbols:
+
 * ``-`` = Layer illegal for the device
 * ``+`` = Layer allowed to overlap
 * ``D`` = DRAWN indicates that a layer is drawn by Design.

--- a/docs/rules/layers/table-f2b-mask-key.rst
+++ b/docs/rules/layers/table-f2b-mask-key.rst
@@ -1,4 +1,5 @@
 Explanation of symbols:
+
 * ``-`` = Layer not created for the device
 * ``+`` = Layer allowed to overlap
 * ``C`` = CREATED

--- a/docs/rules/summary.rst
+++ b/docs/rules/summary.rst
@@ -1,5 +1,5 @@
-Summry of Key Periphery Rules
-=============================
+Summary of Key Periphery Rules
+==============================
 
 .. csv-table:: Table F3a: Front end layers (Low Voltage Devices)
    :file: summary/table-f3a-font-end-low-voltage.csv


### PR DESCRIPTION
`WARNING: Footnote [#] is not referenced` is caused by cross-document footnote linking.
Unfortunately, this is not supported by Sphinx/RST 
https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#footnotes

One solution is to use citations, which are global. 
This has two drawbacks: references cannot be numeric, and the html theme opens a new page after clicking the ref.

Another solution is to simply avoid cross-linking by including the footnotes in parent.
This PR implements second solution.

Fixes #161 
