### PR TITLE
Evaluate dumping .lib.json without indentantion

### DIFF
--- a/.github/workflows/jsonsize.yml
+++ b/.github/workflows/jsonsize.yml
@@ -1,0 +1,20 @@
+name: JSON size opt
+
+on:
+  push:
+
+jobs:
+
+  json:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - run: |
+        for d in ./libraries/*; do
+          git submodule update --init "$d"/latest
+        done
+
+    - run: ./jsonsize.py

--- a/jsonsize.py
+++ b/jsonsize.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from json import dumps, loads
+
+ROOT = Path(__file__).resolve().parent / 'libraries'
+
+def printSize(key, origSize, dumpSize):
+    _GB = (1024 * 1024 * 1024)
+    print(
+        f'{key}:',
+        origSize / _GB, 'GB',
+        '->',
+        dumpSize / _GB, 'GB',
+        f"[{100*dumpSize/origSize}%]" if origSize != 0 else ""
+    )
+
+origSize = {}
+dumpSize = {}
+
+# For each library
+for _dir in ROOT.iterdir():
+    _dname = _dir.name
+
+    # Check latest version only
+    _verdir = _dir / 'latest'
+
+    # Initialize size counters
+    origSize[_dname] = 0
+    dumpSize[_dname] = 0
+
+    # For each '*.lib.json' file (recursively)
+    for item in _verdir.glob('**/*.lib.json'):
+        # Get and accumulate size
+        origSize[_dname] += item.stat().st_size
+        # Read and dump
+        _dump = Path(str(item) + '.dump')
+        _dump.write_text(dumps(loads(item.read_bytes())))
+        # Get and accumulate dump size
+        dumpSize[_dname] += _dump.stat().st_size
+        # Remove dump
+        _dump.unlink()
+
+# Print summary
+_GB = (1024 * 1024 * 1024)
+origTotal = 0
+dumpTotal = 0
+for key, val in origSize.items():
+    _dump = dumpSize[key]
+    printSize(key, val, _dump)
+    origTotal += val
+    dumpTotal += _dump
+
+printSize('Total', origTotal, dumpTotal)


### PR DESCRIPTION
This is a draft for showing some CI results. NOT TO BE MERGED.

> https://twitter.com/wavedrom/status/1383289045812273157
> @mithro  you would probably shave few Gigs from 42GB #skywaterPDK by storing single-line JSON files instead of nicely indented files

In this PR, a workflow and a Python script are added. The script searches all `*.lib.json` files in `libraries/*/latest` and `_dump.write_text(dumps(loads(item.read_bytes())))`. Results show that the size can be reduced to ~39%:

```
sky130_fd_sc_hd: 0.427467473782599 GB -> 0.1797396233305335 GB [42.047555511076226%]
sky130_fd_sc_hvl: 0.14845740050077438 GB -> 0.06090841814875603 GB [41.0275391750769%]
sky130_fd_sc_lp: 2.0116734048351645 GB -> 0.7661424418911338 GB [38.084832262019745%]
sky130_fd_io: 0.0 GB -> 0.0 GB 
sky130_fd_sc_hs: 2.260457427240908 GB -> 0.8601267794147134 GB [38.05100547567381%]
sky130_fd_sc_ms: 1.9792483588680625 GB -> 0.7715314263477921 GB [38.98103150576985%]
sky130_fd_sc_ls: 2.31650467030704 GB -> 0.936532448977232 GB [40.42868814303317%]
sky130_fd_sc_hdll: 0.5418667104095221 GB -> 0.21883693151175976 GB [40.38574935640006%]
sky130_fd_pr: 0.0 GB -> 0.0 GB 
Total: 9.68567544594407 GB -> 3.7938180696219206 GB [39.16937017759151%]
```

/cc @mithro @drom