### PR TITLE
Work Around pypa/pip#10237

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -25,4 +25,4 @@ dependencies:
 - netlistsvg
 # Packages installed from PyPI
 - pip:
-  - -r file:requirements.txt
+  - -r requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,4 @@ dependencies:
 - pip
 # Packages installed from PyPI
 - pip:
-  - -r file:requirements.txt
+  - -r requirements.txt


### PR DESCRIPTION
A regression in PIP causes make env to fail with:

`AttributeError: 'FileNotFoundError' object has no attribute 'read'`

Incidentally, file://requirements.txt does not work:

`ValueError: non-local file URIs are not supported on this platform: 'file://requirements.txt'`

Fixes #332

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR (Not Applicable/No interface change)