### PR TITLE
Update documentation on build space from sp to bd

### DIFF
--- a/docs/contents/libraries.rst
+++ b/docs/contents/libraries.rst
@@ -34,7 +34,7 @@ All sections are **lower case** and separated by an **underscore**. The sections
   +--------------------------------+---------------------------------------+
   | Digital Standard Cells         | :lib_type:`sc`                        |
   +--------------------------------+---------------------------------------+
-  | Build Space (Flash, SRAM, etc) | :lib_type:`sp`                        |
+  | Build Space (Flash, SRAM, etc) | :lib_type:`bd`                        |
   +--------------------------------+---------------------------------------+
   | IO and Periphery               | :lib_type:`io`                        |
   +--------------------------------+---------------------------------------+


### PR DESCRIPTION
It was decided that sp is too close to single port, and should be renamed bd to reference the build space.

Fixes #338 

> It's a good idea to open an issue first for discussion.

- [ x ] Tests pass
- [ x ] Appropriate changes to README are included in PR