### PR TITLE
docs/environment: do not require yosys

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,7 +20,6 @@ channels:
 dependencies:
 - python=3.8
 - pip
-- yosys
 - netlistsvg
 # Packages installed from PyPI
 - pip:


### PR DESCRIPTION
Building the docs is failing because package `yosys` is missing. However, it seems not to be used/required. This PR removes it from the environment file.