### PR TITLE
docs: add References through BibTeX

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,11 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinxcontrib_hdl_diagrams',
+    'sphinxcontrib.bibtex',
 ]
+
+bibtex_default_style = 'plain'
+bibtex_bibfiles = ['refs.bib']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@
     contributing
     partners
 
-
+    references
 
 
 Welcome to SkyWater SKY130 PDK's documentation!

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,0 +1,8 @@
+.. _References:
+
+References
+##########
+
+.. bibliography::
+  :notcited:
+  :labelprefix: R

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,0 +1,6 @@
+@Online{SkyWaterPDKIntro_Edwards21,
+  author = {Edwards, Tim},
+  title = {{Introduction to the SkyWater PDK: The New Age of Open Source Silicon}},
+  url = {https://isn.ucsd.edu/courses/beng207/lectures/Tim_Edwards_2021_slides.pdf},
+  year = {2021},
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ git+https://github.com/SymbiFlow/sphinx_symbiflow_theme.git#egg=sphinx-symbiflow
 docutils
 sphinx
 sphinx-autobuild
+sphinxcontrib-bibtex
 
 # Verilog domain
 sphinx-verilog-domain


### PR DESCRIPTION
This PR is based on #366.

Add a BibTeX file (`refs.bib`) and use it in the documentation through extension `sphinxcontrib-bibtex`.