### PR TITLE
Reorder "Device Details" Sections

### DIFF
--- a/docs/rules/device-details.py
+++ b/docs/rules/device-details.py
@@ -29,9 +29,9 @@ device_list = [
 
     # 20V MOS
     "nfet_20v0",
-    "nfet_20v0_iso",
     "nfet_20v0_nvt",
     "nfet_20v0_zvt",
+    "nfet_20v0_iso",
     "pfet_20v0",
 
     # ESD MOS

--- a/docs/rules/device-details.py
+++ b/docs/rules/device-details.py
@@ -2,28 +2,66 @@
 
 import re
 import os
-import sys
-from pathlib import Path
-from pprint import pformat
-
 
 RE_IMAGE = re.compile('.. (.*) image:: (.*)')
 RE_INCLUDE = re.compile('.. include:: (.*)')
+
+device_list = [
+    # 1.8V MOS
+    "nfet_01v8",
+    "nfet_01v8_lvt",
+    "pfet_01v8",
+    "pfet_01v8_lvt",
+    "pfet_01v8_hvt",
+    "cap_var",
+
+    # 3.3V MOS
+    "nfet_03v3_nvt",
+
+    # 5V MOS
+    "nfet_05v0_nvt",
+    "nfet_g5v0d10v5",
+    "pfet_g5v0d10v5",
+    "pfet_g5v0d16v0",
+
+    # 11V MOS
+    "nfet_g11v0d16v0",
+
+    # 20V MOS
+    "nfet_20v0",
+    "nfet_20v0_iso",
+    "nfet_20v0_nvt",
+    "nfet_20v0_zvt",
+    "pfet_20v0",
+
+    # ESD MOS
+    "esd_nfet",
+
+    # Diodes/Bipolar
+    "diodes",
+    "npn_05v0",
+    "pnp_05v0",
+
+    # Special active devices
+    "special_sram",
+    "special_sonosfet",
+
+    # Well/Diffusion/Poly/Metal Resistors
+    "res_generic",
+    "res_high",
+    "res_xhigh",
+
+    # Metal Capacitors
+    "cap_mim",
+    "cap_vpp",
+]
 
 print('Device Details')
 print('==============')
 print()
 
-def r(m):
-    n = m.group(0)
-    while len(n) < 10:
-        n = '0'+n
-    return n
-
-def k(s):
-    return re.sub('([0-9.V/]*)', r, str(s))
-
-for fname in sorted(Path('.').rglob('index.rst'), key=k):
+for device_name in device_list:
+    fname = os.path.join("device-details", device_name, "index.rst")
 
     with open(fname) as f:
         data = f.read()
@@ -33,4 +71,3 @@ for fname in sorted(Path('.').rglob('index.rst'), key=k):
     data = RE_IMAGE.sub(r'.. \1 image:: {}/\2'.format(dirname), data)
     data = RE_INCLUDE.sub(r'.. include:: {}/\1'.format(dirname), data)
     print(data)
-

--- a/docs/rules/device-details.rst
+++ b/docs/rules/device-details.rst
@@ -216,7 +216,7 @@ The cross-section of the high-VT PMOS FET is shown below. The cross-section is i
 .. |cross-section-pfet_01v8_hvt| image:: device-details/pfet_01v8_hvt/cross-section-pfet_01v8_hvt.svg
 
 
-1.8V Accumulation-Mode MOS Varactors
+1.8V accumulation-mode MOS varactors
 ------------------------------------
 
 Spice Model Information
@@ -545,45 +545,6 @@ The cross-section of the 20V NMOS FET is shown below.
 .. |cross-section-nfet_20v0| image:: device-details/nfet_20v0/cross-section-nfet_20v0.svg
 
 
-20V isolated NMOS FET
----------------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__nfet_extenddrain`
--  Model Name: :model:`sky130_fd_pr__nfet_20v0_iso`
-
-Operating Voltages where SPICE models are valid, subject to SOA limitations:
-
--  :math:`V_{DS} = 0` to +22V
--  :math:`V_{GS} = 0` to 5.5V
--  :math:`V_{BS} = 0` to -2.0V
-
-Details
-~~~~~~~
-
-The 20V isolated NMOS FET has the same construction as the 20V NMOS FET, but is built over a Deep N-well. This permits the p-well to be isolated from the substrate and permit “high-side” usage (where the PW body is held above ground).
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/nfet_20v0_iso/nfet_20v0_iso-table0.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__nfet_20v0_iso` (20V isolated NMOS FET) is shown below.
-
-|symbol-nfet_20v0_iso|
-
-The cross-section of the 20V isolated NMOS FET is shown below.
-
-|cross-section-nfet_20v0_iso|
-
-.. |symbol-nfet_20v0_iso| image:: device-details/nfet_20v0_iso/symbol-nfet_20v0_iso.svg
-.. |cross-section-nfet_20v0_iso| image:: device-details/nfet_20v0_iso/cross-section-nfet_20v0_iso.svg
-
-
 20V native NMOS FET
 -------------------
 
@@ -623,7 +584,7 @@ The cross-section of the 20V native NMOS FET is shown below.
 .. |cross-section-nfet_20v0_nvt| image:: device-details/nfet_20v0_nvt/cross-section-nfet_20v0_nvt.svg
 
 
-20V NMOS zero-VT FET
+20V zero-VT NMOS FET
 --------------------
 
 Spice Model Information
@@ -657,6 +618,45 @@ The cross-section of the 20V NMOS zero-VT FET is shown below.
 |cross-section-nfet_20v0_zvt|
 
 .. |cross-section-nfet_20v0_zvt| image:: device-details/nfet_20v0_zvt/cross-section-nfet_20v0_zvt.svg
+
+
+20V isolated NMOS FET
+---------------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__nfet_extenddrain`
+-  Model Name: :model:`sky130_fd_pr__nfet_20v0_iso`
+
+Operating Voltages where SPICE models are valid, subject to SOA limitations:
+
+-  :math:`V_{DS} = 0` to +22V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
+
+Details
+~~~~~~~
+
+The 20V isolated NMOS FET has the same construction as the 20V NMOS FET, but is built over a Deep N-well. This permits the p-well to be isolated from the substrate and permit “high-side” usage (where the PW body is held above ground).
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/nfet_20v0_iso/nfet_20v0_iso-table0.rst
+
+
+
+The symbol of the :model:`sky130_fd_pr__nfet_20v0_iso` (20V isolated NMOS FET) is shown below.
+
+|symbol-nfet_20v0_iso|
+
+The cross-section of the 20V isolated NMOS FET is shown below.
+
+|cross-section-nfet_20v0_iso|
+
+.. |symbol-nfet_20v0_iso| image:: device-details/nfet_20v0_iso/symbol-nfet_20v0_iso.svg
+.. |cross-section-nfet_20v0_iso| image:: device-details/nfet_20v0_iso/cross-section-nfet_20v0_iso.svg
 
 
 20V PMOS FET
@@ -703,7 +703,7 @@ The cross-section of the 20V PMOS FET is shown below.
 .. |cross-section-pfet_20v0| image:: device-details/pfet_20v0/cross-section-pfet_20v0.svg
 
 
-NMOS ESD FET
+ESD NMOS FET
 ------------
 
 Spice Model Information
@@ -809,8 +809,8 @@ Symbols for the diodes are shown below
 .. |symbol-diode-17| image:: device-details/diodes/symbol-diode-17.svg
 
 
-Bipolar (NPN)
--------------
+Bipolar NPN transistor
+----------------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -861,8 +861,8 @@ The cross-section of the :model:`sky130_fd_pr__npn_11v0` is shown below. The pol
 .. |cross-section-npn_11v0| image:: device-details/npn_05v0/cross-section-npn_11v0.svg
 
 
-Bipolar (PNP)
--------------
+Bipolar PNP transistor
+----------------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1022,7 +1022,7 @@ The cross-section of the 2-T SONOS cell is shown below.
 .. |cross-section-sonos-cell| image:: device-details/special_sonosfet/cross-section-sonos-cell.svg
 
 
-Generic Resistors
+Generic resistors
 -----------------
 
 Generic resistors are supported in the PDK but are not recommended for analog applications. Resistor values will be extracted from the layout as long as the resistor layer is utilized, for LVS against schematic elements.
@@ -1214,8 +1214,8 @@ A generic version of the poly resistor is also available, which permits user inp
 .. |symbol-res_xhigh_po| image:: device-details/res_xhigh/symbol-res_xhigh_po.svg
 
 
-MiM Capacitor
--------------
+MiM capacitors
+--------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rules/device-details.rst
+++ b/docs/rules/device-details.rst
@@ -1,371 +1,43 @@
 Device Details
 ==============
 
-MiM Capacitor
+1.8V NMOS FET
 -------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  Cell Name: :cell:`sky130_fd_pr__cap_mim_m3__base`, :cell:`sky130_fd_pr__cap_mim_m4__base`
--  Model Names: :model:`sky130_fd_pr__model__cap_mim`, :model:`sky130_fd_pr__cap_mim_m4`
-
-Operating Voltages where SPICE models are valid
-
--  :math:`|V_{c0} – V_{c1}| = 0` to 5.0V
-
-Details
-~~~~~~~
-
-The MiM capacitor is constructed using a thin dielectric over metal, followed by a thin conductor layer on top of the dielectric. There are two possible constructions:
-
--  CAPM over Metal-3
--  CAP2M over Metal-4
-
-The constructions are identical, and the capacitors may be stacked to maximize total capacitance.
-
-Electrical specs are listed below:
-
-
-.. include:: device-details/cap_mim/cap_mim-table0.rst
-
-
-
-The symbol for the MiM capacitor is shown below. Note that the cap model is a sub-circuit which accounts for the parasitic contact resistance and the parasitic capacitance from the bottom plate to substrate.
-
-|symbol-cap_mim|
-
-Cell name
-
-M \* W \* L
-
-Calc capacitance
-
-The cross-section of the “stacked” MiM capacitor is shown below:
-
-|cross-section-cap_mim|
-
-.. |symbol-cap_mim| image:: device-details/cap_mim/symbol-cap_mim.svg
-.. |cross-section-cap_mim| image:: device-details/cap_mim/cross-section-cap_mim.svg
-
-
-Varactors
----------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`capbn_b`
--  Model Name: :model:`sky130_fd_pr__cap_var_lvt`, :model:`sky130_fd_pr__cap_var_hvt`
--  Model Type: subcircuit
-
-Operating Voltages where SPICE models are valid
-
--  :math:`|V_0 – V_1| = 0` to 2.0V
-
-Details
-~~~~~~~
-
-The following devices are available; they are subcircuits with the N-well to P-substrate diodes built into the model:
-
--  :model:`sky130_fd_pr__cap_var_lvt` - low VT PMOS device option
--  :model:`sky130_fd_pr__cap_var_hvt` - high VT PMOS device option
-
-The varactors are used as tunable capacitors, major e-test parameters are listed below. Further details on the device models and their usage are in the SKY130 process Family Spice Models (002-21997), which can be obtained from SkyWater upon request.
-
-
-.. include:: device-details/cap_var/cap_var-table0.rst
-
-
-
-There is no equivalent varactor for 5V operation. The NHV or PHV devices should be connected as capacitors for use at 5V.
-
-The symbols for the varactors are shown below:
-
-|symbol-cap_var-a| |symbol-cap_var-b|
-
-The cross-section of the varactor is shown below:
-
-|cross-section-cap_var|
-
-.. |symbol-cap_var-a| image:: device-details/cap_var/symbol-cap_var-a.svg
-.. |symbol-cap_var-b| image:: device-details/cap_var/symbol-cap_var-b.svg
-.. |cross-section-cap_var| image:: device-details/cap_var/cross-section-cap_var.svg
-
-
-Vertical Parallel Plate (VPP) capacitors
-----------------------------------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__cap_vpp_XXpXxYYpY_{MM}(_shield(SS)*)(_float(FF)*)(_(VVVV))`
--  Model Names: :model:`sky130_fd_pr__cap_vpp_*`
-
-   -  X and Y are size dimentions
-   -  MM refers to the layers which are used for the capacitance
-   -  SS refers to the layers which are used as shields (`noshield` when no shield is used)
-   -  FF refers to the layers which are floating.
-   -  VVVVV refers to the "variant" when there are multiple devices of the same configuration
-
-Operating Voltages where SPICE models are valid
-
--  :math:`|V_{c0} – V_{c1}| = 0` to 5.5V
-
-Details
-~~~~~~~
-
-The VPP caps utilize the tight spacings of the metal lines to create capacitors using the available metal layers. The fingers go in opposite directions to minimize alignment-related variability, and the capacitor sits on field oxide to minimize silicon capacitance effects. A schematic diagram of the layout is shown below:
-
-.. todo::
-
-    M3
-
-    **M2**
-
-    LI
-
-    M1
-
-    LAYOUT of M2, M3, M4
-
-    LAYOUT of LI and M1 (with POLY sheet)
-
-    **POLY**
-
-    **M4**
-
-These capacitors are fixed-size, and they can be connected together to multiply the effective capacitance of a given node. There are two different constructions.
-
-Parallel VPP Capacitors
-^^^^^^^^^^^^^^^^^^^^^^^
-
-These are older versions, where stacked metal lines run parallel:
-
-
--  :model:`sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_noshield` (M1 \|\| M2 only, 7.84 x 8.58)
--  :model:`sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_o2` (M1 \|\| M2 only, 4.38 x 4.59)
--  :model:`sky130_fd_pr__cap_vpp_02p4x04p6_m1m2_noshield` (M1 \|\| M2 only, 2.19 x 4.59)
--  :model:`sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield` (M1 :sub:`┴` M2, 4.4 x 4.6, 4 quadrants)
--  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_noshield` (M1 :sub:`┴` M2, 11.5 x 11.7, 4 quadrants)
--  :model:`sky130_fd_pr__cap_vpp_44p7x23p1_pol1m1m2m3m4m5_noshield`
--  :model:`sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 5.0)
--  :model:`sky130_fd_pr__cap_vpp_02p9x06p1_m1m2m3m4_shieldl1_fingercap2` (M1 \|\| M2 \|\| M3 \|\| M4, 2.85 x 5.0)
--  :model:`sky130_fd_pr__cap_vpp_02p7x11p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 10.0)
--  :model:`sky130_fd_pr__cap_vpp_02p7x21p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 20.0)
--  :model:`sky130_fd_pr__cap_vpp_02p7x41p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 40.0)
-
-The symbol for these capacitors is shown below. The terminals c0 and c1 represent the two sides of the capacitor, with b as the body (sub or well).
-
-|symbol-cap_vpp-parallel|
-
-Perpendicular VPP Capacitors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-These are newer versions, where stacked metal lines run perpendicular and there are shields on top and bottom:
-
--  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5` (11.5x11.7, with M5 shield)
--  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5` (11.5x11.7, with poly and M5 shield)
--  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5` (11.5x11.7, with LI and M5 shield)
--  :model:`sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4` (4.4x4.6, M3 float, LI / M5 shield)
--  :model:`sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4` (8.6x7.9, M3 float, LI / M5 shield)
--  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4` (11.5x11.7, M3 float, LI / M5 shield)
--  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4` (11.5x11.7, with M4 shield)
--  :model:`sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4` (6.8x6.1, with poly and M4 shield)
--  :model:`sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4` (6.8x6.1, with LI and M4 shield)
--  :model:`sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5` (11.5x11.7, over 2 :model:`sky130_fd_pr__nfet_05v0_nvt` of 10/4 each)
-
-The symbol for these capacitors is shown below. The terminals c0 and c1 are the two capacitor terminals, “top” represents the top shield and “sub” the bottom shield.
-
-|symbol-cap_vpp-perpendicular|
-
-The capacitors are fixed-size elements and must be used as-is; they can be used in multiples.
-
-
-.. include:: device-details/cap_vpp/cap_vpp-table0.rst
-
-.. |symbol-cap_vpp-parallel| image:: device-details/cap_vpp/symbol-cap_vpp-parallel.svg
-.. |symbol-cap_vpp-perpendicular| image:: device-details/cap_vpp/symbol-cap_vpp-perpendicular.svg
-
-Diodes
-------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`diode`
--  Model Names: :model:`sky130_fd_pr__diode_pw2nd_05v5`, :model:`sky130_fd_pr__diode_pw2nd_11v0`, :model:`sky130_fd_pr__diode_pw2nd_05v5_nvt`, :model:`sky130_fd_pr__diode_pw2nd_05v5_lvt`, :model:`sky130_fd_pr__diode_pd2nw_05v5`, :model:`sky130_fd_pr__diode_pd2nw_11v0`, :model:`sky130_fd_pr__diode_pd2nw_05v5_hvt`, :model:`sky130_fd_pr__diode_pd2nw_05v5_lvt`, :model:`sky130_fd_pr__model__parasitic__rf_diode_ps2nw`, :model:`sky130_fd_pr__model__parasitic__rf_diode_pw2dn`, :model:`sky130_fd_pr__model__parasitic__diode_pw2dn`, :model:`sky130_fd_pr__model__parasitic__diode_ps2dn`, :model:`dnwdiode_psub_victim`, :model:`dnwdiode_psub_aggressor`, :model:`sky130_fd_pr__model__parasitic__diode_ps2nw`, :model:`nwdiode_victim`, :model:`nwdiode_aggressor`, :model:`xesd_ndiode_h_X`, :model:`xesd_ndiode_h_dnwl_X`, :model:`xesd_pdiode_h_X (X = 100 or 200 or 300)`
--  Cell Name: :cell:`lvsdiode`
--  Model Names: :model:`sky130_fd_pr__diode_pw2nd_05v5`, :model:`sky130_fd_pr__diode_pw2nd_11v0`, :model:`sky130_fd_pr__diode_pd2nw_05v5`, :model:`sky130_fd_pr__diode_pd2nw_11v0`, :model:`sky130_fd_pr__model__parasitic__diode_ps2dn`, :model:`dnwdiode_psub_victim`, :model:`dnwdiode_psub_aggressor`, :model:`nwdiode_victim`, :model:`nwdiode_aggressor`, :model:`xesd_ndiode_h_X`, :model:`xesd_ndiode_h_dnwl_X`, :model:`xesd_pdiode_h_X (X = 100 or 200 or 300)`
-
-Operating regime where SPICE models are valid
-
--  :math:`|V_{d0} – V_{d1}| = 0` to 5.0V
-
-Details
-~~~~~~~
-
-
-.. include:: device-details/diodes/diodes-table0.rst
-
-
-
-Symbols for the diodes are shown below
-
-|symbol-diode-01|
-|symbol-diode-02|
-|symbol-diode-03|
-|symbol-diode-04|
-|symbol-diode-05|
-|symbol-diode-06|
-|symbol-diode-07|
-|symbol-diode-08|
-|symbol-diode-09|
-|symbol-diode-10|
-|symbol-diode-11|
-|symbol-diode-12|
-|symbol-diode-13|
-|symbol-diode-14|
-|symbol-diode-15|
-|symbol-diode-16|
-|symbol-diode-17|
-
-.. |symbol-diode-01| image:: device-details/diodes/symbol-diode-01.svg
-.. |symbol-diode-02| image:: device-details/diodes/symbol-diode-02.svg
-.. |symbol-diode-03| image:: device-details/diodes/symbol-diode-03.svg
-.. |symbol-diode-04| image:: device-details/diodes/symbol-diode-04.svg
-.. |symbol-diode-05| image:: device-details/diodes/symbol-diode-05.svg
-.. |symbol-diode-06| image:: device-details/diodes/symbol-diode-06.svg
-.. |symbol-diode-07| image:: device-details/diodes/symbol-diode-07.svg
-.. |symbol-diode-08| image:: device-details/diodes/symbol-diode-08.svg
-.. |symbol-diode-09| image:: device-details/diodes/symbol-diode-09.svg
-.. |symbol-diode-10| image:: device-details/diodes/symbol-diode-10.svg
-.. |symbol-diode-11| image:: device-details/diodes/symbol-diode-11.svg
-.. |symbol-diode-12| image:: device-details/diodes/symbol-diode-12.svg
-.. |symbol-diode-13| image:: device-details/diodes/symbol-diode-13.svg
-.. |symbol-diode-14| image:: device-details/diodes/symbol-diode-14.svg
-.. |symbol-diode-15| image:: device-details/diodes/symbol-diode-15.svg
-.. |symbol-diode-16| image:: device-details/diodes/symbol-diode-16.svg
-.. |symbol-diode-17| image:: device-details/diodes/symbol-diode-17.svg
-
-
-NMOS ESD FET
-------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
 -  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
--  Model Name: :model:`sky130_fd_pr__esd_nfet_01v8`, :model:`sky130_fd_pr__esd_nfet_g5v0d10v5`, :model:`sky130_fd_pr__esd_nfet_g5v0d10v5_nvt`
+-  Model Name: :model:`sky130_fd_pr__nfet_01v8`
 
 Operating Voltages where SPICE models are valid
 
--  :math:`V_{DS} = 0` to 11.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
--  :math:`V_{GS} = 0` to 5.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
--  :math:`V_{BS} = 0` to -5.5V, (:model:`sky130_fd_pr__nfet_g5v0d10v5`), +0.3 to -5.5V (:model:`sky130_fd_pr__nfet_05v0_nvt`), 0 to -1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{DS} = 0` to 1.95V
+-  :math:`V_{GS} = 0` to 1.95V
+-  :math:`V_{BS} = +0.3` to -1.95V
 
 Details
 ~~~~~~~
 
-The ESD FET’s differ from the regular NMOS devices in several aspects, most notably:
-
--  Increased isolation spacing from contacts to surrounding STI
--  Increased drain contact-to-gate spacing
--  Placement of n-well under the drain contacts
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
+Major model output parameters are shown below and compared against the EDR (e-test) specs.
 
 
-.. include:: device-details/esd_nfet/esd_nfet-table0.rst
+.. include:: device-details/nfet_01v8/nfet_01v8-table0.rst
 
 
 
-The symbols of the :model:`sky130_fd_pr__esd_nfet_g5v0d10v5` and :model:`sky130_fd_pr__esd_nfet_g5v0d10v5_nvt` (ESD NMOS FET) are shown below:
+The symbol of the :model:`sky130_fd_pr__nfet_01v8` (1.8V NMOS FET) is shown below:
 
-|symbol-esd_nfet_g5v0d10v5| |symbol-esd_nfet_g5v0d10v5_nvt|
+|symbol-nfet_01v8|
 
-The cross-section of the ESD NMOS FET is shown below.
+The cross-section of the NMOS FET is shown below:
 
-|cross-section-esd_nfet|
+|cross-section-nfet_01v8|
 
-.. |symbol-esd_nfet_g5v0d10v5| image:: device-details/esd_nfet/symbol-esd_nfet_g5v0d10v5.svg
-.. |symbol-esd_nfet_g5v0d10v5_nvt| image:: device-details/esd_nfet/symbol-esd_nfet_g5v0d10v5_nvt.svg
-.. |cross-section-esd_nfet| image:: device-details/esd_nfet/cross-section-esd_nfet.svg
+The device shows the p-well inside of a deep n-well, but it can be made either with or without the DNW under the p-well
 
-
-5.0V/10.5V NMOS FET
--------------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
--  Model Name: :model:`sky130_fd_pr__nfet_g5v0d10v5`
-
-Operating Voltages where SPICE models are valid
-
--  :math:`V_{DS} = 0` to 11.0V
--  :math:`V_{GS} = 0` to 5.5V
--  :math:`V_{BS} = 0` to -5.5V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/nfet_g5v0d10v5/nfet_g5v0d10v5-table0.rst
-
-
-
-The symbols of the :model:`sky130_fd_pr__nfet_g5v0d10v5` (5.0/10.5 V NMOS FET) is shown below:
-
-|symbol-nfet_g5v0d10v5|
-
-The cross-section of the 5.0/10.5 V NMOS FET is shown below.
-
-|cross-section-nfet_g5v0d10v5|
-
-.. |symbol-nfet_g5v0d10v5| image:: device-details/nfet_g5v0d10v5/symbol-nfet_g5v0d10v5.svg
-.. |cross-section-nfet_g5v0d10v5| image:: device-details/nfet_g5v0d10v5/cross-section-nfet_g5v0d10v5.svg
-
-
-11V/16V NMOS FET
-----------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__nfet_extenddrain`
--  Model Name: :model:`sky130_fd_pr__nfet_g5v0d16v0`
-
-Operating Voltages where SPICE models are valid, subject to SOA limitations:
-
--  :math:`V_{DS} = 0` to +16V (\ :math:`V_{GS} = 0`\ )
--  :math:`V_{DS} = 0` to +11V (\ :math:`V_{GS} > 0`\ )
--  :math:`V_{GS} = 0` to 5.5V
--  :math:`V_{BS} = 0` to -2.0V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/nfet_g11v0d16v0/nfet_g11v0d16v0-table0.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__nfet_g5v0d16v0` (11V/16V NMOS FET) is shown below:
-
-|symbol-nfet_g11v0d16v0|
-
-The cross-section of the 11V/16VV NMOS FET is shown below.
-
-|cross-section-nfet_g11v0d16v0|
-
-.. |symbol-nfet_g11v0d16v0| image:: device-details/nfet_g11v0d16v0/symbol-nfet_g11v0d16v0.svg
-.. |cross-section-nfet_g11v0d16v0| image:: device-details/nfet_g11v0d16v0/cross-section-nfet_g11v0d16v0.svg
+.. |symbol-nfet_01v8| image:: device-details/nfet_01v8/symbol-nfet_01v8.svg
+.. |cross-section-nfet_01v8| image:: device-details/nfet_01v8/cross-section-nfet_01v8.svg
 
 
 1.8V low-VT NMOS FET
@@ -412,20 +84,20 @@ The cross-section of the low-VT NMOS FET is shown below. The cross-section is id
 .. |cross-section-nfet_01v8_lvt| image:: device-details/nfet_01v8_lvt/cross-section-nfet_01v8_lvt.svg
 
 
-1.8V NMOS FET
+1.8V PMOS FET
 -------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
--  Model Name: :model:`sky130_fd_pr__nfet_01v8`
+-  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
+-  Model Name: :model:`sky130_fd_pr__pfet_01v8`
 
 Operating Voltages where SPICE models are valid
 
--  :math:`V_{DS} = 0` to 1.95V
--  :math:`V_{GS} = 0` to 1.95V
--  :math:`V_{BS} = +0.3` to -1.95V
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
 
 Details
 ~~~~~~~
@@ -433,22 +105,159 @@ Details
 Major model output parameters are shown below and compared against the EDR (e-test) specs.
 
 
-.. include:: device-details/nfet_01v8/nfet_01v8-table0.rst
+.. include:: device-details/pfet_01v8/pfet_01v8-table0.rst
 
 
 
-The symbol of the :model:`sky130_fd_pr__nfet_01v8` (1.8V NMOS FET) is shown below:
+Inverter Gate Delays using sky130_fd_pr__nfet_01v8/:model:`sky130_fd_pr__pfet_01v8` device combinations:
 
-|symbol-nfet_01v8|
 
-The cross-section of the NMOS FET is shown below:
+.. include:: device-details/pfet_01v8/pfet_01v8-table1.rst
 
-|cross-section-nfet_01v8|
 
-The device shows the p-well inside of a deep n-well, but it can be made either with or without the DNW under the p-well
 
-.. |symbol-nfet_01v8| image:: device-details/nfet_01v8/symbol-nfet_01v8.svg
-.. |cross-section-nfet_01v8| image:: device-details/nfet_01v8/cross-section-nfet_01v8.svg
+The symbol of the :model:`sky130_fd_pr__pfet_01v8` (1.8V PMOS FET) is shown below:
+
+|symbol-pfet_01v8|
+
+The cross-section of the PMOS FET is shown below:
+
+|cross-section-pfet_01v8|
+
+.. |symbol-pfet_01v8| image:: device-details/pfet_01v8/symbol-pfet_01v8.svg
+.. |cross-section-pfet_01v8| image:: device-details/pfet_01v8/cross-section-pfet_01v8.svg
+
+
+1.8V low-VT PMOS FET
+--------------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
+-  Model Name: :model:`sky130_fd_pr__pfet_01v8_lvt`
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
+
+Details
+~~~~~~~
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/pfet_01v8_lvt/pfet_01v8_lvt-table0.rst
+
+
+
+Inverter Gate Delays using sky130_fd_pr__nfet_01v8_lvt/:model:`sky130_fd_pr__pfet_01v8_lvt` device combinations:
+
+
+.. include:: device-details/pfet_01v8_lvt/pfet_01v8_lvt-table1.rst
+
+
+
+The symbol of the :model:`sky130_fd_pr__pfet_01v8_lvt` (1.8V low-VT PMOS FET) is shown below:
+
+|symbol-pfet_01v8_lvt|
+
+The cross-section of the low-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the lower :math:`V_T`)
+
+|cross-section-pfet_01v8_lvt|
+
+.. |symbol-pfet_01v8_lvt| image:: device-details/pfet_01v8_lvt/symbol-pfet_01v8_lvt.svg
+.. |cross-section-pfet_01v8_lvt| image:: device-details/pfet_01v8_lvt/cross-section-pfet_01v8_lvt.svg
+
+
+1.8V high-VT PMOS FET
+---------------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
+-  Model Name: :model:`sky130_fd_pr__pfet_01v8_hvt`
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`V_{DS} = 0` to -1.95V
+-  :math:`V_{GS} = 0` to -1.95V
+-  :math:`V_{BS} = -0.1` to +1.95V
+
+Details
+~~~~~~~
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/pfet_01v8_hvt/pfet_01v8_hvt-table0.rst
+
+
+
+Inverter Gate Delays using sky130_fd_pr__nfet_01v8/:model:`sky130_fd_pr__pfet_01v8_hvt` device combinations:
+
+
+.. include:: device-details/pfet_01v8_hvt/pfet_01v8_hvt-table1.rst
+
+
+
+The symbol of the :model:`sky130_fd_pr__pfet_01v8_hvt` (1.8V high-VT PMOS FET) is shown below:
+
+|symbol-pfet_01v8_hvt|
+
+The cross-section of the high-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the higher :math:`V_T`)
+
+|cross-section-pfet_01v8_hvt|
+
+.. |symbol-pfet_01v8_hvt| image:: device-details/pfet_01v8_hvt/symbol-pfet_01v8_hvt.svg
+.. |cross-section-pfet_01v8_hvt| image:: device-details/pfet_01v8_hvt/cross-section-pfet_01v8_hvt.svg
+
+
+1.8V Accumulation-Mode MOS Varactors
+------------------------------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`capbn_b`
+-  Model Name: :model:`sky130_fd_pr__cap_var_lvt`, :model:`sky130_fd_pr__cap_var_hvt`
+-  Model Type: subcircuit
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`|V_0 – V_1| = 0` to 2.0V
+
+Details
+~~~~~~~
+
+The following devices are available; they are subcircuits with the N-well to P-substrate diodes built into the model:
+
+-  :model:`sky130_fd_pr__cap_var_lvt` - low VT PMOS device option
+-  :model:`sky130_fd_pr__cap_var_hvt` - high VT PMOS device option
+
+The varactors are used as tunable capacitors, major e-test parameters are listed below. Further details on the device models and their usage are in the SKY130 process Family Spice Models (002-21997), which can be obtained from SkyWater upon request.
+
+
+.. include:: device-details/cap_var/cap_var-table0.rst
+
+
+
+There is no equivalent varactor for 5V operation. The NHV or PHV devices should be connected as capacitors for use at 5V.
+
+The symbols for the varactors are shown below:
+
+|symbol-cap_var-a| |symbol-cap_var-b|
+
+The cross-section of the varactor is shown below:
+
+|cross-section-cap_var|
+
+.. |symbol-cap_var-a| image:: device-details/cap_var/symbol-cap_var-a.svg
+.. |symbol-cap_var-b| image:: device-details/cap_var/symbol-cap_var-b.svg
+.. |cross-section-cap_var| image:: device-details/cap_var/cross-section-cap_var.svg
 
 
 3.0V native NMOS FET
@@ -498,7 +307,7 @@ The cross-section of the native devices is shown below.
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
+-  Cell Name: :cell:`sky130_fd_pr__nfet_05v0_nvt`
 -  Model Name: :model:`sky130_fd_pr__nfet_05v0_nvt`
 
 Operating Voltages where SPICE models are valid for :model:`sky130_fd_pr__nfet_05v0_nvt`
@@ -532,6 +341,164 @@ The cross-section of the native devices is shown below.
 
 .. |symbol-nfet_05v0_nvt| image:: device-details/nfet_05v0_nvt/symbol-nfet_05v0_nvt.svg
 .. |cross-section-nfet_05v0_nvt| image:: device-details/nfet_05v0_nvt/../nfet_03v3_nvt-and-nfet_05v0_nvt/cross-section-nfet_03v3_nvt-and-nfet_05v0_nvt.svg
+
+
+5.0V/10.5V NMOS FET
+-------------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
+-  Model Name: :model:`sky130_fd_pr__nfet_g5v0d10v5`
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`V_{DS} = 0` to 11.0V
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -5.5V
+
+Details
+~~~~~~~
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/nfet_g5v0d10v5/nfet_g5v0d10v5-table0.rst
+
+
+
+The symbols of the :model:`sky130_fd_pr__nfet_g5v0d10v5` (5.0/10.5 V NMOS FET) is shown below:
+
+|symbol-nfet_g5v0d10v5|
+
+The cross-section of the 5.0/10.5 V NMOS FET is shown below.
+
+|cross-section-nfet_g5v0d10v5|
+
+.. |symbol-nfet_g5v0d10v5| image:: device-details/nfet_g5v0d10v5/symbol-nfet_g5v0d10v5.svg
+.. |cross-section-nfet_g5v0d10v5| image:: device-details/nfet_g5v0d10v5/cross-section-nfet_g5v0d10v5.svg
+
+
+5.0V/10.5V PMOS FET
+-------------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
+-  Model Name: :model:`sky130_fd_pr__pfet_g5v0d10v5`, :model:`sky130_fd_pr__esd_pfet_g5v0d10v5`
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`V_{DS} = 0` to -11.0V
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +5.5V
+
+Details
+~~~~~~~
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/pfet_g5v0d10v5/pfet_g5v0d10v5-table0.rst
+
+
+
+Inverter gate delays are shown below:
+
+
+.. include:: device-details/pfet_g5v0d10v5/pfet_g5v0d10v5-table1.rst
+
+
+
+The symbols of the :model:`sky130_fd_pr__pfet_g5v0d10v5` and :model:`sky130_fd_pr__esd_pfet_g5v0d10v5` (5.0V/10.5V PMOS FET) are shown below:
+
+|symbol-pfet_g5v0d10v5| |symbol-esd_pfet_g5v0d10v5|
+
+The cross-section of the 5.0V PMOS FET is shown below.
+
+|cross-section-pfet_g5v0d10v5|
+
+.. |symbol-pfet_g5v0d10v5| image:: device-details/pfet_g5v0d10v5/symbol-pfet_g5v0d10v5.svg
+.. |symbol-esd_pfet_g5v0d10v5| image:: device-details/pfet_g5v0d10v5/symbol-esd_pfet_g5v0d10v5.svg
+.. |cross-section-pfet_g5v0d10v5| image:: device-details/pfet_g5v0d10v5/cross-section-pfet_g5v0d10v5.svg
+
+
+10V/16V PMOS FET
+----------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__pfet_extenddrain`
+-  Model Name: :model:`sky130_fd_pr__pfet_g5v0d16v0`
+
+Operating Voltages where SPICE models are valid, subject to SOA limitations:
+
+-  :math:`V_{DS} = 0` to -16V (\ :math:`V_{GS} = 0`\ )
+-  :math:`V_{DS} = 0` to -10V (\ :math:`V_{GS} < 0`\ )
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +2.0V
+
+Details
+~~~~~~~
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/pfet_g5v0d16v0/pfet_g5v0d16v0-table0.rst
+
+
+
+The symbol of the :model:`sky130_fd_pr__pfet_g5v0d16v0` (10V/16V PMOS FET) is shown below:
+
+|symbol-pfet_g5v0d16v0|
+
+The cross-section of the 10V/16V PMOS FET is shown below.
+
+|cross-section-pfet_g5v0d16v0|
+
+.. |symbol-pfet_g5v0d16v0| image:: device-details/pfet_g5v0d16v0/symbol-pfet_g5v0d16v0.svg
+.. |cross-section-pfet_g5v0d16v0| image:: device-details/pfet_g5v0d16v0/cross-section-pfet_g5v0d16v0.svg
+
+
+11V/16V NMOS FET
+----------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__nfet_extenddrain`
+-  Model Name: :model:`sky130_fd_pr__nfet_g5v0d16v0`
+
+Operating Voltages where SPICE models are valid, subject to SOA limitations:
+
+-  :math:`V_{DS} = 0` to +16V (\ :math:`V_{GS} = 0`\ )
+-  :math:`V_{DS} = 0` to +11V (\ :math:`V_{GS} > 0`\ )
+-  :math:`V_{GS} = 0` to 5.5V
+-  :math:`V_{BS} = 0` to -2.0V
+
+Details
+~~~~~~~
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/nfet_g11v0d16v0/nfet_g11v0d16v0-table0.rst
+
+
+
+The symbol of the :model:`sky130_fd_pr__nfet_g5v0d16v0` (11V/16V NMOS FET) is shown below:
+
+|symbol-nfet_g11v0d16v0|
+
+The cross-section of the 11V/16VV NMOS FET is shown below.
+
+|cross-section-nfet_g11v0d16v0|
+
+.. |symbol-nfet_g11v0d16v0| image:: device-details/nfet_g11v0d16v0/symbol-nfet_g11v0d16v0.svg
+.. |cross-section-nfet_g11v0d16v0| image:: device-details/nfet_g11v0d16v0/cross-section-nfet_g11v0d16v0.svg
 
 
 20V NMOS FET
@@ -692,6 +659,156 @@ The cross-section of the 20V NMOS zero-VT FET is shown below.
 .. |cross-section-nfet_20v0_zvt| image:: device-details/nfet_20v0_zvt/cross-section-nfet_20v0_zvt.svg
 
 
+20V PMOS FET
+------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__pfet_extenddrain`
+-  Model Name: :model:`sky130_fd_pr__pfet_20v0`
+
+Operating Voltages where SPICE models are valid, subject to SOA limitations:
+
+-  :math:`V_{DS} = 0` to -22V
+-  :math:`V_{GS} = 0` to -5.5V
+-  :math:`V_{BS} = 0` to +2.0V
+
+Details
+~~~~~~~
+
+The 20V NMOS FET has similar construction to the 11V/16V NMOS FET, with several differences:
+
+-  Longer drift region
+-  Longer poly gate
+-  Larger W/L
+-  Devices placed in pairs (drain in middle, sources on outside)
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/pfet_20v0/pfet_20v0-table0.rst
+
+
+
+The symbol of the :model:`sky130_fd_pr__pfet_20v0` (20V PMOS FET) is shown below.
+
+|symbol-pfet_20v0|
+
+The cross-section of the 20V PMOS FET is shown below.
+
+|cross-section-pfet_20v0|
+
+.. |symbol-pfet_20v0| image:: device-details/pfet_20v0/symbol-pfet_20v0.svg
+.. |cross-section-pfet_20v0| image:: device-details/pfet_20v0/cross-section-pfet_20v0.svg
+
+
+NMOS ESD FET
+------------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
+-  Model Name: :model:`sky130_fd_pr__esd_nfet_01v8`, :model:`sky130_fd_pr__esd_nfet_g5v0d10v5`, :model:`sky130_fd_pr__esd_nfet_g5v0d10v5_nvt`
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`V_{DS} = 0` to 11.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{GS} = 0` to 5.0V (:model:`sky130_fd_pr__nfet_g5v0d10v5*`), 0 to 1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+-  :math:`V_{BS} = 0` to -5.5V, (:model:`sky130_fd_pr__nfet_g5v0d10v5`), +0.3 to -5.5V (:model:`sky130_fd_pr__nfet_05v0_nvt`), 0 to -1.95V (:model:`sky130_fd_pr__nfet_01v8*`)
+
+Details
+~~~~~~~
+
+The ESD FET’s differ from the regular NMOS devices in several aspects, most notably:
+
+-  Increased isolation spacing from contacts to surrounding STI
+-  Increased drain contact-to-gate spacing
+-  Placement of n-well under the drain contacts
+
+Major model output parameters are shown below and compared against the EDR (e-test) specs
+
+
+.. include:: device-details/esd_nfet/esd_nfet-table0.rst
+
+
+
+The symbols of the :model:`sky130_fd_pr__esd_nfet_g5v0d10v5` and :model:`sky130_fd_pr__esd_nfet_g5v0d10v5_nvt` (ESD NMOS FET) are shown below:
+
+|symbol-esd_nfet_g5v0d10v5| |symbol-esd_nfet_g5v0d10v5_nvt|
+
+The cross-section of the ESD NMOS FET is shown below.
+
+|cross-section-esd_nfet|
+
+.. |symbol-esd_nfet_g5v0d10v5| image:: device-details/esd_nfet/symbol-esd_nfet_g5v0d10v5.svg
+.. |symbol-esd_nfet_g5v0d10v5_nvt| image:: device-details/esd_nfet/symbol-esd_nfet_g5v0d10v5_nvt.svg
+.. |cross-section-esd_nfet| image:: device-details/esd_nfet/cross-section-esd_nfet.svg
+
+
+Diodes
+------
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`diode`
+-  Model Names: :model:`sky130_fd_pr__diode_pw2nd_05v5`, :model:`sky130_fd_pr__diode_pw2nd_11v0`, :model:`sky130_fd_pr__diode_pw2nd_05v5_nvt`, :model:`sky130_fd_pr__diode_pw2nd_05v5_lvt`, :model:`sky130_fd_pr__diode_pd2nw_05v5`, :model:`sky130_fd_pr__diode_pd2nw_11v0`, :model:`sky130_fd_pr__diode_pd2nw_05v5_hvt`, :model:`sky130_fd_pr__diode_pd2nw_05v5_lvt`, :model:`sky130_fd_pr__model__parasitic__rf_diode_ps2nw`, :model:`sky130_fd_pr__model__parasitic__rf_diode_pw2dn`, :model:`sky130_fd_pr__model__parasitic__diode_pw2dn`, :model:`sky130_fd_pr__model__parasitic__diode_ps2dn`, :model:`dnwdiode_psub_victim`, :model:`dnwdiode_psub_aggressor`, :model:`sky130_fd_pr__model__parasitic__diode_ps2nw`, :model:`nwdiode_victim`, :model:`nwdiode_aggressor`, :model:`xesd_ndiode_h_X`, :model:`xesd_ndiode_h_dnwl_X`, :model:`xesd_pdiode_h_X (X = 100 or 200 or 300)`
+-  Cell Name: :cell:`lvsdiode`
+-  Model Names: :model:`sky130_fd_pr__diode_pw2nd_05v5`, :model:`sky130_fd_pr__diode_pw2nd_11v0`, :model:`sky130_fd_pr__diode_pd2nw_05v5`, :model:`sky130_fd_pr__diode_pd2nw_11v0`, :model:`sky130_fd_pr__model__parasitic__diode_ps2dn`, :model:`dnwdiode_psub_victim`, :model:`dnwdiode_psub_aggressor`, :model:`nwdiode_victim`, :model:`nwdiode_aggressor`, :model:`xesd_ndiode_h_X`, :model:`xesd_ndiode_h_dnwl_X`, :model:`xesd_pdiode_h_X (X = 100 or 200 or 300)`
+
+Operating regime where SPICE models are valid
+
+-  :math:`|V_{d0} – V_{d1}| = 0` to 5.0V
+
+Details
+~~~~~~~
+
+
+.. include:: device-details/diodes/diodes-table0.rst
+
+
+
+Symbols for the diodes are shown below
+
+|symbol-diode-01|
+|symbol-diode-02|
+|symbol-diode-03|
+|symbol-diode-04|
+|symbol-diode-05|
+|symbol-diode-06|
+|symbol-diode-07|
+|symbol-diode-08|
+|symbol-diode-09|
+|symbol-diode-10|
+|symbol-diode-11|
+|symbol-diode-12|
+|symbol-diode-13|
+|symbol-diode-14|
+|symbol-diode-15|
+|symbol-diode-16|
+|symbol-diode-17|
+
+.. |symbol-diode-01| image:: device-details/diodes/symbol-diode-01.svg
+.. |symbol-diode-02| image:: device-details/diodes/symbol-diode-02.svg
+.. |symbol-diode-03| image:: device-details/diodes/symbol-diode-03.svg
+.. |symbol-diode-04| image:: device-details/diodes/symbol-diode-04.svg
+.. |symbol-diode-05| image:: device-details/diodes/symbol-diode-05.svg
+.. |symbol-diode-06| image:: device-details/diodes/symbol-diode-06.svg
+.. |symbol-diode-07| image:: device-details/diodes/symbol-diode-07.svg
+.. |symbol-diode-08| image:: device-details/diodes/symbol-diode-08.svg
+.. |symbol-diode-09| image:: device-details/diodes/symbol-diode-09.svg
+.. |symbol-diode-10| image:: device-details/diodes/symbol-diode-10.svg
+.. |symbol-diode-11| image:: device-details/diodes/symbol-diode-11.svg
+.. |symbol-diode-12| image:: device-details/diodes/symbol-diode-12.svg
+.. |symbol-diode-13| image:: device-details/diodes/symbol-diode-13.svg
+.. |symbol-diode-14| image:: device-details/diodes/symbol-diode-14.svg
+.. |symbol-diode-15| image:: device-details/diodes/symbol-diode-15.svg
+.. |symbol-diode-16| image:: device-details/diodes/symbol-diode-16.svg
+.. |symbol-diode-17| image:: device-details/diodes/symbol-diode-17.svg
+
+
 Bipolar (NPN)
 -------------
 
@@ -744,265 +861,6 @@ The cross-section of the :model:`sky130_fd_pr__npn_11v0` is shown below. The pol
 .. |cross-section-npn_11v0| image:: device-details/npn_05v0/cross-section-npn_11v0.svg
 
 
-5.0V/10.5V PMOS FET
--------------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
--  Model Name: :model:`sky130_fd_pr__pfet_g5v0d10v5`, :model:`sky130_fd_pr__esd_pfet_g5v0d10v5`
-
-Operating Voltages where SPICE models are valid
-
--  :math:`V_{DS} = 0` to -11.0V
--  :math:`V_{GS} = 0` to -5.5V
--  :math:`V_{BS} = 0` to +5.5V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/pfet_g5v0d10v5/pfet_g5v0d10v5-table0.rst
-
-
-
-Inverter gate delays are shown below:
-
-
-.. include:: device-details/pfet_g5v0d10v5/pfet_g5v0d10v5-table1.rst
-
-
-
-The symbols of the :model:`sky130_fd_pr__pfet_g5v0d10v5` and :model:`sky130_fd_pr__esd_pfet_g5v0d10v5` (5.0V/10.5V PMOS FET) are shown below:
-
-|symbol-pfet_g5v0d10v5| |symbol-esd_pfet_g5v0d10v5|
-
-The cross-section of the 5.0V PMOS FET is shown below.
-
-|cross-section-pfet_g5v0d10v5|
-
-.. |symbol-pfet_g5v0d10v5| image:: device-details/pfet_g5v0d10v5/symbol-pfet_g5v0d10v5.svg
-.. |symbol-esd_pfet_g5v0d10v5| image:: device-details/pfet_g5v0d10v5/symbol-esd_pfet_g5v0d10v5.svg
-.. |cross-section-pfet_g5v0d10v5| image:: device-details/pfet_g5v0d10v5/cross-section-pfet_g5v0d10v5.svg
-
-
-10V/16V PMOS FET
-----------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_extenddrain`
--  Model Name: :model:`sky130_fd_pr__pfet_g5v0d16v0`
-
-Operating Voltages where SPICE models are valid, subject to SOA limitations:
-
--  :math:`V_{DS} = 0` to -16V (\ :math:`V_{GS} = 0`\ )
--  :math:`V_{DS} = 0` to -10V (\ :math:`V_{GS} < 0`\ )
--  :math:`V_{GS} = 0` to -5.5V
--  :math:`V_{BS} = 0` to +2.0V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/pfet_g5v0d16v0/pfet_g5v0d16v0-table0.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__pfet_g5v0d16v0` (10V/16V PMOS FET) is shown below:
-
-|symbol-pfet_g5v0d16v0|
-
-The cross-section of the 10V/16V PMOS FET is shown below.
-
-|cross-section-pfet_g5v0d16v0|
-
-.. |symbol-pfet_g5v0d16v0| image:: device-details/pfet_g5v0d16v0/symbol-pfet_g5v0d16v0.svg
-.. |cross-section-pfet_g5v0d16v0| image:: device-details/pfet_g5v0d16v0/cross-section-pfet_g5v0d16v0.svg
-
-
-1.8V high-VT PMOS FET
----------------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
--  Model Name: :model:`sky130_fd_pr__pfet_01v8_hvt`
-
-Operating Voltages where SPICE models are valid
-
--  :math:`V_{DS} = 0` to -1.95V
--  :math:`V_{GS} = 0` to -1.95V
--  :math:`V_{BS} = -0.1` to +1.95V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/pfet_01v8_hvt/pfet_01v8_hvt-table0.rst
-
-
-
-Inverter Gate Delays using sky130_fd_pr__nfet_01v8/:model:`sky130_fd_pr__pfet_01v8_hvt` device combinations:
-
-
-.. include:: device-details/pfet_01v8_hvt/pfet_01v8_hvt-table1.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__pfet_01v8_hvt` (1.8V high-VT PMOS FET) is shown below:
-
-|symbol-pfet_01v8_hvt|
-
-The cross-section of the high-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the higher :math:`V_T`)
-
-|cross-section-pfet_01v8_hvt|
-
-.. |symbol-pfet_01v8_hvt| image:: device-details/pfet_01v8_hvt/symbol-pfet_01v8_hvt.svg
-.. |cross-section-pfet_01v8_hvt| image:: device-details/pfet_01v8_hvt/cross-section-pfet_01v8_hvt.svg
-
-
-1.8V low-VT PMOS FET
---------------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
--  Model Name: :model:`sky130_fd_pr__pfet_01v8_lvt`
-
-Operating Voltages where SPICE models are valid
-
--  :math:`V_{DS} = 0` to -1.95V
--  :math:`V_{GS} = 0` to -1.95V
--  :math:`V_{BS} = -0.1` to +1.95V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/pfet_01v8_lvt/pfet_01v8_lvt-table0.rst
-
-
-
-Inverter Gate Delays using sky130_fd_pr__nfet_01v8_lvt/:model:`sky130_fd_pr__pfet_01v8_lvt` device combinations:
-
-
-.. include:: device-details/pfet_01v8_lvt/pfet_01v8_lvt-table1.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__pfet_01v8_lvt` (1.8V low-VT PMOS FET) is shown below:
-
-|symbol-pfet_01v8_lvt|
-
-The cross-section of the low-VT PMOS FET is shown below. The cross-section is identical to the std PMOS FET except for the :math:`V_T` adjust implants (to achieve the lower :math:`V_T`)
-
-|cross-section-pfet_01v8_lvt|
-
-.. |symbol-pfet_01v8_lvt| image:: device-details/pfet_01v8_lvt/symbol-pfet_01v8_lvt.svg
-.. |cross-section-pfet_01v8_lvt| image:: device-details/pfet_01v8_lvt/cross-section-pfet_01v8_lvt.svg
-
-
-1.8V PMOS FET
--------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
--  Model Name: :model:`sky130_fd_pr__pfet_01v8`
-
-Operating Voltages where SPICE models are valid
-
--  :math:`V_{DS} = 0` to -1.95V
--  :math:`V_{GS} = 0` to -1.95V
--  :math:`V_{BS} = -0.1` to +1.95V
-
-Details
-~~~~~~~
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs.
-
-
-.. include:: device-details/pfet_01v8/pfet_01v8-table0.rst
-
-
-
-Inverter Gate Delays using sky130_fd_pr__nfet_01v8/:model:`sky130_fd_pr__pfet_01v8` device combinations:
-
-
-.. include:: device-details/pfet_01v8/pfet_01v8-table1.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__pfet_01v8` (1.8V PMOS FET) is shown below:
-
-|symbol-pfet_01v8|
-
-The cross-section of the PMOS FET is shown below:
-
-|cross-section-pfet_01v8|
-
-.. |symbol-pfet_01v8| image:: device-details/pfet_01v8/symbol-pfet_01v8.svg
-.. |cross-section-pfet_01v8| image:: device-details/pfet_01v8/cross-section-pfet_01v8.svg
-
-
-20V PMOS FET
-------------
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_extenddrain`
--  Model Name: :model:`sky130_fd_pr__pfet_20v0`
-
-Operating Voltages where SPICE models are valid, subject to SOA limitations:
-
--  :math:`V_{DS} = 0` to -22V
--  :math:`V_{GS} = 0` to -5.5V
--  :math:`V_{BS} = 0` to +2.0V
-
-Details
-~~~~~~~
-
-The 20V NMOS FET has similar construction to the 11V/16V NMOS FET, with several differences:
-
--  Longer drift region
--  Longer poly gate
--  Larger W/L
--  Devices placed in pairs (drain in middle, sources on outside)
-
-Major model output parameters are shown below and compared against the EDR (e-test) specs
-
-
-.. include:: device-details/pfet_20v0/pfet_20v0-table0.rst
-
-
-
-The symbol of the :model:`sky130_fd_pr__pfet_20v0` (20V PMOS FET) is shown below.
-
-|symbol-pfet_20v0|
-
-The cross-section of the 20V PMOS FET is shown below.
-
-|cross-section-pfet_20v0|
-
-.. |symbol-pfet_20v0| image:: device-details/pfet_20v0/symbol-pfet_20v0.svg
-.. |cross-section-pfet_20v0| image:: device-details/pfet_20v0/cross-section-pfet_20v0.svg
-
-
 Bipolar (PNP)
 -------------
 
@@ -1048,6 +906,120 @@ No deep n-well exists in this device; the collector is the substrate.
 .. |symbol-pnp_05v0-a| image:: device-details/pnp_05v0/symbol-pnp_05v0-a.svg
 .. |symbol-pnp_05v0-b| image:: device-details/pnp_05v0/symbol-pnp_05v0-b.svg
 .. |cross-section-pnp_05v0| image:: device-details/pnp_05v0/cross-section-pnp_05v0.svg
+
+
+SRAM cells
+----------
+
+The SKY130 process currently supports only single-port SRAM’s, which are contained in hard-IP libraries. These cells are constructed with smaller design rules (Table 9), along with OPC (optical proximity correction) techniques, to achieve small memory cells. Use of the memory cells or their devices outside the specific IP is prohibited. The schematic for the SRAM is shown below in Figure 10. This cell is available in the S8 IP offerings and is monitored at e-test through the use of “pinned out” devices within the specific arrays.
+
+|figure-10-schematics-of-the-single-port-sram|
+
+**Figure 10. Schematics of the Single Port SRAM.**
+
+A Dual-Port SRAM is currently being designed using a similar approach. Compilers for the SP and DP SRAM’s will be available end-2019.
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`V_{DS} = 0` to 1.8V
+-  :math:`V_{GS} = 0` to 1.8V
+-  :math:`V_{BS} = 0` to -1.8V
+
+Details
+~~~~~~~
+
+N-pass FET (SRAM)
+^^^^^^^^^^^^^^^^^
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
+-  Model Name (SRAM): :model:`sky130_fd_pr__special_nfet_pass`
+
+
+.. include:: device-details/special_sram/special_sram-table0.rst
+
+
+
+N-latch FET (SRAM)
+^^^^^^^^^^^^^^^^^^
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
+-  Model Name (SRAM): :model:`sky130_fd_pr__special_nfet_latch`
+
+
+.. include:: device-details/special_sram/special_sram-table1.rst
+
+
+
+P-latch FET (SRAM)
+^^^^^^^^^^^^^^^^^^
+
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
+-  Model Name (SRAM): :model:`sky130_fd_pr__special_pfet_pass`
+
+
+.. include:: device-details/special_sram/special_sram-table2.rst
+
+
+
+.. |figure-10-schematics-of-the-single-port-sram| image:: device-details/special_sram/figure-10-schematics-of-the-single-port-sram.svg
+
+
+SONOS cells
+-----------
+
+The SKY130 process currently supports two SONOS flash memory cells:
+
+-  The original cell is supported in the S8PFHD, S8PHRC and S8PFN-20 technology options, with operating temperatures from -55°C to +155°C
+-  The “star” cell is supported in the S8PHIRS technology option. Its cell size is approximately 25% smaller than the original cell, but its temperature range is restricted to -40°C to +125°C.
+
+Spice models for the memory cells exist for multiple conditions:
+
+
+.. include:: device-details/special_sonosfet/special_sonosfet-table0.rst
+
+
+
+Program and Erase characteristics are described in more detail in the ***S8 Nonvolatile Technology Spec*** (001-08712), and summarized below:
+
+
+.. include:: device-details/special_sonosfet/special_sonosfet-table1.rst
+
+
+
+Endurance behavior is illustrated below (100K cycles guaranteed):
+
+|sonos-erase-program|
+
+Data retention behavior is shown below at 85C\ |sonos-data-retention|
+
+E-test parameters are summarized below for both original and star cells:
+
+
+.. include:: device-details/special_sonosfet/special_sonosfet-table2.rst
+
+
+
+The schematic for the 2-T SONOS memory cell is shown below:
+
+|schematic-sonos-cell|
+
+The cross-section of the 2-T SONOS cell is shown below.
+
+|cross-section-sonos-cell|
+
+.. |sonos-erase-program| image:: device-details/special_sonosfet/sonos-erase-program.svg
+.. |sonos-data-retention| image:: device-details/special_sonosfet/sonos-data-retention.svg
+.. |schematic-sonos-cell| image:: device-details/special_sonosfet/schematic-sonos-cell.svg
+.. |cross-section-sonos-cell| image:: device-details/special_sonosfet/cross-section-sonos-cell.svg
 
 
 Generic Resistors
@@ -1242,117 +1214,145 @@ A generic version of the poly resistor is also available, which permits user inp
 .. |symbol-res_xhigh_po| image:: device-details/res_xhigh/symbol-res_xhigh_po.svg
 
 
-SONOS cells
------------
+MiM Capacitor
+-------------
 
-The SKY130 process currently supports two SONOS flash memory cells:
+Spice Model Information
+~~~~~~~~~~~~~~~~~~~~~~~
 
--  The original cell is supported in the S8PFHD, S8PHRC and S8PFN-20 technology options, with operating temperatures from -55°C to +155°C
--  The “star” cell is supported in the S8PHIRS technology option. Its cell size is approximately 25% smaller than the original cell, but its temperature range is restricted to -40°C to +125°C.
-
-Spice models for the memory cells exist for multiple conditions:
-
-
-.. include:: device-details/special_sonosfet/special_sonosfet-table0.rst
-
-
-
-Program and Erase characteristics are described in more detail in the ***S8 Nonvolatile Technology Spec*** (001-08712), and summarized below:
-
-
-.. include:: device-details/special_sonosfet/special_sonosfet-table1.rst
-
-
-
-Endurance behavior is illustrated below (100K cycles guaranteed):
-
-|sonos-erase-program|
-
-Data retention behavior is shown below at 85C\ |sonos-data-retention|
-
-E-test parameters are summarized below for both original and star cells:
-
-
-.. include:: device-details/special_sonosfet/special_sonosfet-table2.rst
-
-
-
-The schematic for the 2-T SONOS memory cell is shown below:
-
-|schematic-sonos-cell|
-
-The cross-section of the 2-T SONOS cell is shown below.
-
-|cross-section-sonos-cell|
-
-.. |sonos-erase-program| image:: device-details/special_sonosfet/sonos-erase-program.svg
-.. |sonos-data-retention| image:: device-details/special_sonosfet/sonos-data-retention.svg
-.. |schematic-sonos-cell| image:: device-details/special_sonosfet/schematic-sonos-cell.svg
-.. |cross-section-sonos-cell| image:: device-details/special_sonosfet/cross-section-sonos-cell.svg
-
-
-SRAM cells
-----------
-
-The SKY130 process currently supports only single-port SRAM’s, which are contained in hard-IP libraries. These cells are constructed with smaller design rules (Table 9), along with OPC (optical proximity correction) techniques, to achieve small memory cells. Use of the memory cells or their devices outside the specific IP is prohibited. The schematic for the SRAM is shown below in Figure 10. This cell is available in the S8 IP offerings and is monitored at e-test through the use of “pinned out” devices within the specific arrays.
-
-|figure-10-schematics-of-the-single-port-sram|
-
-**Figure 10. Schematics of the Single Port SRAM.**
-
-A Dual-Port SRAM is currently being designed using a similar approach. Compilers for the SP and DP SRAM’s will be available end-2019.
+-  Cell Name: :cell:`sky130_fd_pr__cap_mim_m3__base`, :cell:`sky130_fd_pr__cap_mim_m4__base`
+-  Model Names: :model:`sky130_fd_pr__model__cap_mim`, :model:`sky130_fd_pr__cap_mim_m4`
 
 Operating Voltages where SPICE models are valid
 
--  :math:`V_{DS} = 0` to 1.8V
--  :math:`V_{GS} = 0` to 1.8V
--  :math:`V_{BS} = 0` to -1.8V
+-  :math:`|V_{c0} – V_{c1}| = 0` to 5.0V
 
 Details
 ~~~~~~~
 
-N-pass FET (SRAM)
-^^^^^^^^^^^^^^^^^
+The MiM capacitor is constructed using a thin dielectric over metal, followed by a thin conductor layer on top of the dielectric. There are two possible constructions:
+
+-  CAPM over Metal-3
+-  CAP2M over Metal-4
+
+The constructions are identical, and the capacitors may be stacked to maximize total capacitance.
+
+Electrical specs are listed below:
+
+
+.. include:: device-details/cap_mim/cap_mim-table0.rst
+
+
+
+The symbol for the MiM capacitor is shown below. Note that the cap model is a sub-circuit which accounts for the parasitic contact resistance and the parasitic capacitance from the bottom plate to substrate.
+
+|symbol-cap_mim|
+
+Cell name
+
+M \* W \* L
+
+Calc capacitance
+
+The cross-section of the “stacked” MiM capacitor is shown below:
+
+|cross-section-cap_mim|
+
+.. |symbol-cap_mim| image:: device-details/cap_mim/symbol-cap_mim.svg
+.. |cross-section-cap_mim| image:: device-details/cap_mim/cross-section-cap_mim.svg
+
+
+Vertical Parallel Plate (VPP) capacitors
+----------------------------------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
--  Model Name (SRAM): :model:`sky130_fd_pr__special_nfet_pass`
+-  Cell Name: :cell:`sky130_fd_pr__cap_vpp_XXpXxYYpY_{MM}(_shield(SS)*)(_float(FF)*)(_(VVVV))`
+-  Model Names: :model:`sky130_fd_pr__cap_vpp_*`
+
+   -  X and Y are size dimentions
+   -  MM refers to the layers which are used for the capacitance
+   -  SS refers to the layers which are used as shields (`noshield` when no shield is used)
+   -  FF refers to the layers which are floating.
+   -  VVVVV refers to the "variant" when there are multiple devices of the same configuration
+
+Operating Voltages where SPICE models are valid
+
+-  :math:`|V_{c0} – V_{c1}| = 0` to 5.5V
+
+Details
+~~~~~~~
+
+The VPP caps utilize the tight spacings of the metal lines to create capacitors using the available metal layers. The fingers go in opposite directions to minimize alignment-related variability, and the capacitor sits on field oxide to minimize silicon capacitance effects. A schematic diagram of the layout is shown below:
+
+.. todo::
+
+    M3
+
+    **M2**
+
+    LI
+
+    M1
+
+    LAYOUT of M2, M3, M4
+
+    LAYOUT of LI and M1 (with POLY sheet)
+
+    **POLY**
+
+    **M4**
+
+These capacitors are fixed-size, and they can be connected together to multiply the effective capacitance of a given node. There are two different constructions.
+
+Parallel VPP Capacitors
+^^^^^^^^^^^^^^^^^^^^^^^
+
+These are older versions, where stacked metal lines run parallel:
 
 
-.. include:: device-details/special_sram/special_sram-table0.rst
+-  :model:`sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_noshield` (M1 \|\| M2 only, 7.84 x 8.58)
+-  :model:`sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_o2` (M1 \|\| M2 only, 4.38 x 4.59)
+-  :model:`sky130_fd_pr__cap_vpp_02p4x04p6_m1m2_noshield` (M1 \|\| M2 only, 2.19 x 4.59)
+-  :model:`sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield` (M1 :sub:`┴` M2, 4.4 x 4.6, 4 quadrants)
+-  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_noshield` (M1 :sub:`┴` M2, 11.5 x 11.7, 4 quadrants)
+-  :model:`sky130_fd_pr__cap_vpp_44p7x23p1_pol1m1m2m3m4m5_noshield`
+-  :model:`sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 5.0)
+-  :model:`sky130_fd_pr__cap_vpp_02p9x06p1_m1m2m3m4_shieldl1_fingercap2` (M1 \|\| M2 \|\| M3 \|\| M4, 2.85 x 5.0)
+-  :model:`sky130_fd_pr__cap_vpp_02p7x11p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 10.0)
+-  :model:`sky130_fd_pr__cap_vpp_02p7x21p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 20.0)
+-  :model:`sky130_fd_pr__cap_vpp_02p7x41p1_m1m2m3m4_shieldl1_fingercap` (M1 \|\| M2 \|\| M3 \|\| M4, 2.7 x 40.0)
+
+The symbol for these capacitors is shown below. The terminals c0 and c1 represent the two sides of the capacitor, with b as the body (sub or well).
+
+|symbol-cap_vpp-parallel|
+
+Perpendicular VPP Capacitors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These are newer versions, where stacked metal lines run perpendicular and there are shields on top and bottom:
+
+-  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5` (11.5x11.7, with M5 shield)
+-  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5` (11.5x11.7, with poly and M5 shield)
+-  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5` (11.5x11.7, with LI and M5 shield)
+-  :model:`sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4` (4.4x4.6, M3 float, LI / M5 shield)
+-  :model:`sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4` (8.6x7.9, M3 float, LI / M5 shield)
+-  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4` (11.5x11.7, M3 float, LI / M5 shield)
+-  :model:`sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4` (11.5x11.7, with M4 shield)
+-  :model:`sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4` (6.8x6.1, with poly and M4 shield)
+-  :model:`sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4` (6.8x6.1, with LI and M4 shield)
+-  :model:`sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5` (11.5x11.7, over 2 :model:`sky130_fd_pr__nfet_05v0_nvt` of 10/4 each)
+
+The symbol for these capacitors is shown below. The terminals c0 and c1 are the two capacitor terminals, “top” represents the top shield and “sub” the bottom shield.
+
+|symbol-cap_vpp-perpendicular|
+
+The capacitors are fixed-size elements and must be used as-is; they can be used in multiples.
 
 
+.. include:: device-details/cap_vpp/cap_vpp-table0.rst
 
-N-latch FET (SRAM)
-^^^^^^^^^^^^^^^^^^
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__nfet_01v8`
--  Model Name (SRAM): :model:`sky130_fd_pr__special_nfet_latch`
-
-
-.. include:: device-details/special_sram/special_sram-table1.rst
-
-
-
-P-latch FET (SRAM)
-^^^^^^^^^^^^^^^^^^
-
-Spice Model Information
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Cell Name: :cell:`sky130_fd_pr__pfet_01v8`
--  Model Name (SRAM): :model:`sky130_fd_pr__special_pfet_pass`
-
-
-.. include:: device-details/special_sram/special_sram-table2.rst
-
-
-
-.. |figure-10-schematics-of-the-single-port-sram| image:: device-details/special_sram/figure-10-schematics-of-the-single-port-sram.svg
-
+.. |symbol-cap_vpp-parallel| image:: device-details/cap_vpp/symbol-cap_vpp-parallel.svg
+.. |symbol-cap_vpp-perpendicular| image:: device-details/cap_vpp/symbol-cap_vpp-perpendicular.svg
 

--- a/docs/rules/device-details/cap_mim/index.rst
+++ b/docs/rules/device-details/cap_mim/index.rst
@@ -1,5 +1,5 @@
-MiM Capacitor
--------------
+MiM capacitors
+--------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rules/device-details/cap_var/index.rst
+++ b/docs/rules/device-details/cap_var/index.rst
@@ -1,5 +1,5 @@
-Varactors
----------
+1.8V Accumulation-Mode MOS Varactors
+------------------------------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rules/device-details/cap_var/index.rst
+++ b/docs/rules/device-details/cap_var/index.rst
@@ -1,4 +1,4 @@
-1.8V Accumulation-Mode MOS Varactors
+1.8V accumulation-mode MOS varactors
 ------------------------------------
 
 Spice Model Information

--- a/docs/rules/device-details/esd_nfet/index.rst
+++ b/docs/rules/device-details/esd_nfet/index.rst
@@ -1,4 +1,4 @@
-NMOS ESD FET
+ESD NMOS FET
 ------------
 
 Spice Model Information

--- a/docs/rules/device-details/nfet_20v0_zvt/index.rst
+++ b/docs/rules/device-details/nfet_20v0_zvt/index.rst
@@ -1,4 +1,4 @@
-20V NMOS zero-VT FET
+20V zero-VT NMOS FET
 --------------------
 
 Spice Model Information

--- a/docs/rules/device-details/npn_05v0/index.rst
+++ b/docs/rules/device-details/npn_05v0/index.rst
@@ -1,5 +1,5 @@
-Bipolar (NPN)
--------------
+Bipolar NPN transistor
+----------------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rules/device-details/pnp_05v0/index.rst
+++ b/docs/rules/device-details/pnp_05v0/index.rst
@@ -1,5 +1,5 @@
-Bipolar (PNP)
--------------
+Bipolar PNP transistor
+----------------------
 
 Spice Model Information
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rules/device-details/res_generic/index.rst
+++ b/docs/rules/device-details/res_generic/index.rst
@@ -1,4 +1,4 @@
-Generic Resistors
+Generic resistors
 -----------------
 
 Generic resistors are supported in the PDK but are not recommended for analog applications. Resistor values will be extracted from the layout as long as the resistor layer is utilized, for LVS against schematic elements.


### PR DESCRIPTION
From a designer's point of view, I found the order in which devices are listed in the "Design Rules" -> "Device Details" section extremely confusing.

With this MR I propose to re-order them in a more intiuitive way: Starting with the core (1.8 V) MOS devices, followed by high voltage/ESD variants, then bipolars, special cells and finally passives. I also found it more appropriate to list the MOS varactors close to the core active devices, this is where they are typically listed in PDK documentation in my experience.